### PR TITLE
Make room name a type definition

### DIFF
--- a/livekit/types.go
+++ b/livekit/types.go
@@ -7,4 +7,27 @@ type ParticipantIdentity = string
 type ParticipantName = string
 
 type RoomID = string
-type RoomName = string
+
+//----------------------------------------------------------------
+
+type RoomName string
+
+func RoomNamesAsStrings(roomNames []RoomName) []string {
+	var asString []string
+	for _, roomName := range roomNames {
+		asString = append(asString, string(roomName))
+	}
+
+	return asString
+}
+
+func StringsAsRoomNames(roomNames []string) []RoomName {
+	var asRoomName []RoomName
+	for _, roomName := range roomNames {
+		asRoomName = append(asRoomName, RoomName(roomName))
+	}
+
+	return asRoomName
+}
+
+//----------------------------------------------------------------


### PR DESCRIPTION
Will submit PRs for code depending on this.

@davidzhao @frostbyte73 Was thinking of doing
- A `String()` method of `RoomName` to convert to string
- A `NewRoomName(roomName string) livekit.RoomName` to convert from string.
That would make it more idiomatic and also keep it flexible for the future (although I am guessing we are never going to change it from being a string).

But, did not do those methods in this PR and doing straight casting at call sites.

Please let me know if I should switch to these methods to make things cleaner and I can amend this PR.