### PR TITLE
Added ForcePathStyle to S3Upload

### DIFF
--- a/livekit/livekit_egress.pb.go
+++ b/livekit/livekit_egress.pb.go
@@ -1245,11 +1245,12 @@ type S3Upload struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	AccessKey string `protobuf:"bytes,1,opt,name=access_key,json=accessKey,proto3" json:"access_key,omitempty"`
-	Secret    string `protobuf:"bytes,2,opt,name=secret,proto3" json:"secret,omitempty"`
-	Region    string `protobuf:"bytes,3,opt,name=region,proto3" json:"region,omitempty"`
-	Endpoint  string `protobuf:"bytes,4,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
-	Bucket    string `protobuf:"bytes,5,opt,name=bucket,proto3" json:"bucket,omitempty"`
+	AccessKey      string `protobuf:"bytes,1,opt,name=access_key,json=accessKey,proto3" json:"access_key,omitempty"`
+	Secret         string `protobuf:"bytes,2,opt,name=secret,proto3" json:"secret,omitempty"`
+	Region         string `protobuf:"bytes,3,opt,name=region,proto3" json:"region,omitempty"`
+	Endpoint       string `protobuf:"bytes,4,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
+	Bucket         string `protobuf:"bytes,5,opt,name=bucket,proto3" json:"bucket,omitempty"`
+	ForcePathStyle bool   `protobuf:"bytes,6,opt,name=force_path_style,proto3" json:"force_path_style,omitempty"`
 }
 
 func (x *S3Upload) Reset() {

--- a/livekit_egress.proto
+++ b/livekit_egress.proto
@@ -115,6 +115,7 @@ message S3Upload {
   string region = 3;
   string endpoint = 4;
   string bucket = 5;
+  bool force_path_style = 6;
 }
 
 message GCPUpload {


### PR DESCRIPTION
I use minio.

I noticed errors
```
"RequestError: send request failed\ncaused by: Put \"http://files.minio:9000/chat/1/recording_1665442848.mp4.json\": dial tcp: lookup files.minio: no such host"
```

in egress if I use like normal code
```
chatId, err := utils.ParseInt64(c.Param("id"))
	if err != nil {
		return err
	}
	roomName := fmt.Sprintf("chat%v", chatId)
	filePath := fmt.Sprintf("/chat/%v/recording_%v.mp4", chatId, time.Now().Unix())
	s3u := livekit.EncodedFileOutput_S3{
		S3: &livekit.S3Upload{
			AccessKey: "AKIAIOSFODNN7EXAMPLE",
			Secret:    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
			Region:    "europe-east",
			Endpoint:  "http://minio:9000",
			Bucket:    "files",
		},
	}
	streamRequest := &livekit.RoomCompositeEgressRequest{
		RoomName: roomName,
		Layout:   "speaker-dark",
		Output: &livekit.RoomCompositeEgressRequest_File{
			File: &livekit.EncodedFileOutput{
				FileType: livekit.EncodedFileType_MP4,
				Filepath: filePath,
				Output:   &s3u,
			},
		},
		AudioOnly: false,
		VideoOnly: false,
		Options: &livekit.RoomCompositeEgressRequest_Preset{
			Preset: livekit.EncodingOptionsPreset_H264_720P_30,
		},
	}

	info, err := rh.egressClient.StartRoomCompositeEgress(c.Request().Context(), streamRequest)
	if err != nil {
		GetLogEntry(c.Request().Context()).Errorf("Error during starting recording %v", err)
		return err
	}
```

I found that it can be fixed by setting `S3ForcePathStyle: true` here: https://github.com/livekit/egress/blob/82ae12e9def0336d31e1c8708458a3e59163762e/pkg/pipeline/sink/upload.go#L35

So in this PR I add it to the protocol.

After this PR I am going to make PR to egress and server-sdk-go.