### PR TITLE
Fallback to osstat if a matching cgroup implementation cannot be found, and fix core count computation

### DIFF
--- a/utils/cpu_all.go
+++ b/utils/cpu_all.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"runtime"
+
+	"github.com/mackerelio/go-osstat/cpu"
+)
+
+type osstatCPUMonitor struct {
+	prev *cpu.Stats
+}
+
+func newOsstatCPUMonitor() (*osstatCPUMonitor, error) {
+	stats, err := cpu.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return &osstatCPUMonitor{
+		prev: stats,
+	}, nil
+}
+
+func (p *osstatCPUMonitor) getCPUIdle() (float64, error) {
+	next, err := cpu.Get()
+	if err != nil {
+		return 0, err
+	}
+	idleRatio := float64(next.Idle-p.prev.Idle) / float64(next.Total-p.prev.Total)
+	p.prev = next
+
+	return float64(p.numCPU()) * idleRatio, nil
+}
+
+func (p *osstatCPUMonitor) numCPU() int {
+	return runtime.NumCPU()
+}

--- a/utils/cpu_linux.go
+++ b/utils/cpu_linux.go
@@ -4,11 +4,15 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/livekit/protocol/logger"
 )
 
 var (
@@ -18,49 +22,65 @@ var (
 const (
 	cpuStatsPathV1 = "/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage"
 	cpuStatsPathV2 = "/sys/fs/cgroup/cpu.stat"
+
+	numCPUPathV1 = "/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage_percpu"
+	numCPUPathV2 = "/sys/fs/cgroup/cpu.max"
 )
 
-type platformCPUMonitor struct {
-	lastSampleTime   int64
-	lastTotalCPUTime int64
-
-	cpuTimeFunc func() (int64, error)
+type cpuInfoGetter interface {
+	getTotalCPUTime() (int64, error)
+	numCPU() (int, error)
 }
 
-func newPlatformCPUMonitor() (*platformCPUMonitor, error) {
+type cgroupCPUMonitor struct {
+	lastSampleTime   int64
+	lastTotalCPUTime int64
+	nCPU             int
+
+	cg cpuInfoGetter
+}
+
+func newPlatformCPUMonitor() (platformCPUMonitor, error) {
 	// probe for the cgroup version
-	var cpuTimeFunc func() (int64, error)
-	for k, v := range map[string]func() (int64, error){
-		cpuStatsPathV1: getTotalCPUTimeV1,
-		cpuStatsPathV2: getTotalCPUTimeV2,
+	var cg cpuInfoGetter
+	for k, v := range map[string]func() cpuInfoGetter{
+		cpuStatsPathV1: newCpuInfoGetterV1,
+		cpuStatsPathV2: newCpuInfoGetterV2,
 	} {
 		e, err := fileExists(k)
 		if err != nil {
 			return nil, err
 		}
 		if e {
-			cpuTimeFunc = v
+			cg = v()
 			break
 		}
 	}
-	if cpuTimeFunc == nil {
-		return nil, errors.New("failed reading cpu stats file")
+	if cg == nil {
+		logger.Infow("failed reading cgroup specific cpu stats, falling back to system wide implementation")
+		return newOsstatCPUMonitor()
 	}
 
-	cpu, err := cpuTimeFunc()
+	cpu, err := cg.getTotalCPUTime()
 	if err != nil {
 		return nil, err
 	}
 
-	return &platformCPUMonitor{
+	nCPU, err := cg.numCPU()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cgroupCPUMonitor{
 		lastSampleTime:   time.Now().UnixNano(),
 		lastTotalCPUTime: cpu,
-		cpuTimeFunc:      cpuTimeFunc,
+		nCPU:             nCPU,
+		cg:               cg,
 	}, nil
 }
 
-func (p *platformCPUMonitor) getCPUIdle() (float64, error) {
-	next, err := p.cpuTimeFunc()
+func (p *cgroupCPUMonitor) getCPUIdle() (float64, error) {
+	next, err := p.cg.getTotalCPUTime()
 	if err != nil {
 		return 0, err
 	}
@@ -70,11 +90,11 @@ func (p *platformCPUMonitor) getCPUIdle() (float64, error) {
 	cpuTime := next - p.lastTotalCPUTime
 
 	busyRatio := float64(cpuTime) / float64(duration)
-	idleRatio := float64(runtime.NumCPU()) - busyRatio
+	idleRatio := float64(p.nCPU) - busyRatio
 
 	// Clamp the value as we do not get all the timestamps at the same time
-	if idleRatio > float64(runtime.NumCPU()) {
-		idleRatio = float64(runtime.NumCPU())
+	if idleRatio > float64(p.nCPU) {
+		idleRatio = float64(p.nCPU)
 	} else if idleRatio < 0 {
 		idleRatio = 0
 	}
@@ -85,7 +105,18 @@ func (p *platformCPUMonitor) getCPUIdle() (float64, error) {
 	return idleRatio, nil
 }
 
-func getTotalCPUTimeV1() (int64, error) {
+func (p *cgroupCPUMonitor) numCPU() int {
+	return p.nCPU
+}
+
+type cpuInfoGetterV1 struct {
+}
+
+func newCpuInfoGetterV1() cpuInfoGetter {
+	return &cpuInfoGetterV1{}
+}
+
+func (cg *cpuInfoGetterV1) getTotalCPUTime() (int64, error) {
 	b, err := os.ReadFile(cpuStatsPathV1)
 	if err != nil {
 		return 0, err
@@ -100,7 +131,36 @@ func getTotalCPUTimeV1() (int64, error) {
 	return i, nil
 }
 
-func getTotalCPUTimeV2() (int64, error) {
+func (cg *cpuInfoGetterV1) numCPU() (int, error) {
+	b, err := os.ReadFile(numCPUPathV1)
+	if err != nil {
+		return 0, err
+	}
+
+	// Remove trailing new line if any
+	s := strings.TrimSuffix(string(b), "\n")
+
+	// Remove trailing space if any
+	s = strings.TrimSuffix(s, " ")
+
+	m := strings.Split(s, " ")
+	if len(m) == 0 {
+		return 0, errors.New("could not parse cpu stats")
+	}
+
+	fmt.Println("CPU", m)
+
+	return len(m), nil
+}
+
+type cpuInfoGetterV2 struct {
+}
+
+func newCpuInfoGetterV2() cpuInfoGetter {
+	return &cpuInfoGetterV2{}
+}
+
+func (cg *cpuInfoGetterV2) getTotalCPUTime() (int64, error) {
 	b, err := os.ReadFile(cpuStatsPathV2)
 	if err != nil {
 		return 0, err
@@ -118,6 +178,37 @@ func getTotalCPUTimeV2() (int64, error) {
 
 	// Caller expexts time in ns
 	return i * 1000, nil
+}
+
+func (cg *cpuInfoGetterV2) numCPU() (int, error) {
+	b, err := os.ReadFile(numCPUPathV2)
+	if err != nil {
+		return 0, err
+	}
+
+	s := strings.TrimSuffix(string(b), "\n")
+
+	m := strings.Split(s, " ")
+	if len(m) <= 1 {
+		return 0, errors.New("could not parse cpu stats")
+	}
+
+	if m[0] == "max" {
+		// No quota
+		return runtime.NumCPU(), nil
+	} else {
+		n, err := strconv.ParseInt(string(m[0]), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+
+		d, err := strconv.ParseInt(string(m[1]), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+
+		return int(n / d), nil
+	}
 }
 
 func fileExists(path string) (bool, error) {

--- a/utils/cpu_nonlinux.go
+++ b/utils/cpu_nonlinux.go
@@ -2,35 +2,6 @@
 
 package utils
 
-import (
-	"runtime"
-
-	"github.com/mackerelio/go-osstat/cpu"
-)
-
-type platformCPUMonitor struct {
-	prev *cpu.Stats
-}
-
-func newPlatformCPUMonitor() (*platformCPUMonitor, error) {
-	stats, err := cpu.Get()
-	if err != nil {
-		return nil, err
-	}
-
-	return &platformCPUMonitor{
-		prev: stats,
-	}, nil
-}
-
-func (p *platformCPUMonitor) getCPUIdle() (float64, error) {
-	next, err := cpu.Get()
-	if err != nil {
-		return 0, err
-	}
-	idleRatio := float64(next.Idle-p.prev.Idle) / float64(next.Total-p.prev.Total)
-	p.prev = next
-
-	return float64(runtime.NumCPU()) * idleRatio, nil
-
+func newPlatformCPUMonitor() (platformCPUMonitor, error) {
+	return newOsstatCPUMonitor()
 }


### PR DESCRIPTION
This should fix WSL2 support.