### PR TITLE
Support for participant-level log sampling

### DIFF
--- a/logger/config.go
+++ b/logger/config.go
@@ -1,11 +1,23 @@
 package logger
 
 type Config struct {
-	JSON   bool   `yaml:"json"`
-	Level  string `yaml:"level"`
-	Sample bool   `yaml:"sample,omitempty"`
+	JSON  bool   `yaml:"json"`
+	Level string `yaml:"level"`
+	// true to enable log sampling, where the same log message and level will be throttled.
+	// we have two layers of sampling
+	// 1. global sampling - within a second, it will log the first SampleInitial, then every SampleInterval messages.
+	// 2. per participant/track sampling - to be used with Logger.WithItemSampler(). This would be used to throttle
+	//    the logs for a particular participant/track.
+	Sample bool `yaml:"sample,omitempty"`
+
+	// global sampling per server
 	// when sampling, the first N logs will be logged
-	SampleInitial int `yaml:"sampleInitial,omitempty"`
+	SampleInitial int `yaml:"sample_initial,omitempty"`
 	// when sampling, every Mth log will be logged
-	SampleInterval int `yaml:"sampleInterval,omitempty"`
+	SampleInterval int `yaml:"sample_interval,omitempty"`
+
+	// participant/track level sampling
+	ItemSampleSeconds  int `yaml:"item_sample_seconds,omitempty"`
+	ItemSampleInitial  int `yaml:"item_sample_initial,omitempty"`
+	ItemSampleInterval int `yaml:"item_sample_interval,omitempty"`
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -120,7 +120,7 @@ func (l *ZapLogger) Warnw(msg string, err error, keysAndValues ...interface{}) {
 	if err != nil {
 		keysAndValues = append(keysAndValues, "error", err)
 	}
-	l.zap.Errorw(msg, keysAndValues...)
+	l.zap.Warnw(msg, keysAndValues...)
 }
 
 func (l *ZapLogger) Errorw(msg string, err error, keysAndValues ...interface{}) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,15 +1,17 @@
 package logger
 
 import (
+	"time"
+
 	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 var (
-	defaultLogger = logr.Discard()
-	pkgLogger     = Logger(logr.Discard())
+	discardLogger        = logr.Discard()
+	defaultLogger Logger = LogRLogger(discardLogger)
+	pkgLogger     Logger = LogRLogger(discardLogger)
 )
 
 // InitFromConfig initializes a Zap-based logger
@@ -41,25 +43,25 @@ func InitFromConfig(conf Config, name string) {
 		zapConfig.EncoderConfig = zap.NewProductionEncoderConfig()
 	}
 	l, _ := zapConfig.Build()
-	zapLogger := zapr.NewLogger(l)
-	SetLogger(zapLogger, name)
+	zl := &ZapLogger{
+		zap:            l.Sugar(),
+		SampleDuration: time.Duration(conf.SampleInterval) * time.Second,
+		SampleInitial:  conf.ItemSampleInitial,
+		SampleInterval: conf.ItemSampleInterval,
+	}
+	SetLogger(zl, name)
 }
 
 // GetLogger returns the logger that was set with SetLogger with an extra depth of 1
-func GetLogger() logr.Logger {
+func GetLogger() Logger {
 	return defaultLogger
 }
 
-// GetDefaultLogger returns the logger that was set but with LiveKit wrappers
-func GetDefaultLogger() Logger {
-	return Logger(defaultLogger)
-}
-
 // SetLogger lets you use a custom logger. Pass in a logr.Logger with default depth
-func SetLogger(l logr.Logger, name string) {
+func SetLogger(l Logger, name string) {
 	defaultLogger = l.WithCallDepth(1).WithName(name)
 	// pkg wrapper needs to drop two levels of depth
-	pkgLogger = Logger(l.WithCallDepth(2).WithName(name))
+	pkgLogger = l.WithCallDepth(2).WithName(name)
 }
 
 func Debugw(msg string, keysAndValues ...interface{}) {
@@ -86,30 +88,124 @@ func ParseZapLevel(level string) zapcore.Level {
 	return lvl
 }
 
-type Logger logr.Logger
+type Logger interface {
+	Debugw(msg string, keysAndValues ...interface{})
+	Infow(msg string, keysAndValues ...interface{})
+	Warnw(msg string, err error, keysAndValues ...interface{})
+	Errorw(msg string, err error, keysAndValues ...interface{})
+	WithValues(keysAndValues ...interface{}) Logger
+	WithName(name string) Logger
+	WithCallDepth(depth int) Logger
+	WithItemSampler() Logger
+}
 
-func (l Logger) toLogr() logr.Logger {
+type ZapLogger struct {
+	zap *zap.SugaredLogger
+	// avoid multiple item samplers
+	hasItemSampler bool
+	SampleDuration time.Duration
+	SampleInitial  int
+	SampleInterval int
+}
+
+func (l *ZapLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	l.zap.Debugw(msg, keysAndValues...)
+}
+
+func (l *ZapLogger) Infow(msg string, keysAndValues ...interface{}) {
+	l.zap.Infow(msg, keysAndValues...)
+}
+
+func (l *ZapLogger) Warnw(msg string, err error, keysAndValues ...interface{}) {
+	if err != nil {
+		keysAndValues = append(keysAndValues, "error", err)
+	}
+	l.zap.Errorw(msg, keysAndValues...)
+}
+
+func (l *ZapLogger) Errorw(msg string, err error, keysAndValues ...interface{}) {
+	if err != nil {
+		keysAndValues = append(keysAndValues, "error", err)
+	}
+	l.zap.Errorw(msg, keysAndValues...)
+}
+
+func (l *ZapLogger) WithValues(keysAndValues ...interface{}) Logger {
+	dup := *l
+	dup.zap = l.zap.With(keysAndValues...)
+	return &dup
+}
+
+func (l *ZapLogger) WithName(name string) Logger {
+	dup := *l
+	dup.zap = l.zap.Named(name)
+	return &dup
+}
+
+func (l *ZapLogger) WithCallDepth(depth int) Logger {
+	dup := *l
+	dup.zap = l.zap.WithOptions(zap.AddCallerSkip(depth))
+	return &dup
+}
+
+func (l *ZapLogger) WithItemSampler() Logger {
+	if l.hasItemSampler || l.SampleDuration == 0 {
+		return l
+	}
+	dup := *l
+	dup.zap = l.zap.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return zapcore.NewSamplerWithOptions(
+			core,
+			l.SampleDuration,
+			l.SampleInitial,
+			l.SampleInterval,
+		)
+	}))
+	dup.hasItemSampler = true
+	return &dup
+}
+
+type LogRLogger logr.Logger
+
+func (l LogRLogger) toLogr() logr.Logger {
 	if logr.Logger(l).GetSink() == nil {
-		return defaultLogger
+		return discardLogger
 	}
 	return logr.Logger(l)
 }
 
-func (l Logger) Debugw(msg string, keysAndValues ...interface{}) {
+func (l LogRLogger) Debugw(msg string, keysAndValues ...interface{}) {
 	l.toLogr().V(1).Info(msg, keysAndValues...)
 }
 
-func (l Logger) Infow(msg string, keysAndValues ...interface{}) {
+func (l LogRLogger) Infow(msg string, keysAndValues ...interface{}) {
 	l.toLogr().Info(msg, keysAndValues...)
 }
 
-func (l Logger) Warnw(msg string, err error, keysAndValues ...interface{}) {
+func (l LogRLogger) Warnw(msg string, err error, keysAndValues ...interface{}) {
 	if err != nil {
 		keysAndValues = append(keysAndValues, "error", err)
 	}
 	l.toLogr().Info(msg, keysAndValues...)
 }
 
-func (l Logger) Errorw(msg string, err error, keysAndValues ...interface{}) {
+func (l LogRLogger) Errorw(msg string, err error, keysAndValues ...interface{}) {
 	l.toLogr().Error(err, msg, keysAndValues...)
+}
+
+func (l LogRLogger) WithValues(keysAndValues ...interface{}) Logger {
+	return LogRLogger(l.toLogr().WithValues(keysAndValues...))
+}
+
+func (l LogRLogger) WithName(name string) Logger {
+	return LogRLogger(l.toLogr().WithName(name))
+}
+
+func (l LogRLogger) WithCallDepth(depth int) Logger {
+	return LogRLogger(l.toLogr().WithCallDepth(depth))
+}
+
+func (l LogRLogger) WithItemSampler() Logger {
+	// logr does not support sampling
+	return l
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -45,7 +45,7 @@ func InitFromConfig(conf Config, name string) {
 	l, _ := zapConfig.Build()
 	zl := &ZapLogger{
 		zap:            l.Sugar(),
-		SampleDuration: time.Duration(conf.SampleInterval) * time.Second,
+		SampleDuration: time.Duration(conf.ItemSampleSeconds) * time.Second,
 		SampleInitial:  conf.ItemSampleInitial,
 		SampleInterval: conf.ItemSampleInterval,
 	}


### PR DESCRIPTION
Also includes a cleanup of our logging system. Instead of using logr abstraction, we've created our own. It's still possible to use with an existing LogR logger, but by default it'll use Zap directly.

This has an added benefit of supporting Warn level logs. logr does not have a concept of warn, and it's quite annoying.