### PR TITLE
add lock tracker

### DIFF
--- a/utils/lock_tracker.go
+++ b/utils/lock_tracker.go
@@ -1,0 +1,224 @@
+package utils
+
+import (
+	"math"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+var lowResTime uint32 = uint32(time.Now().Unix())
+var weakRefs []uintptr
+var weakRefFree []int
+var weakRefLock sync.Mutex
+
+var startLockTrackerWorkerOnce sync.Once
+
+func StartLockTrackerWorker() {
+	startLockTrackerWorkerOnce.Do(func() {
+		go updateLowResTime()
+	})
+}
+
+func updateLowResTime() {
+	ticker := time.NewTicker(time.Second)
+	for t := range ticker.C {
+		atomic.StoreUint32(&lowResTime, uint32(t.Unix()))
+	}
+}
+
+func SyncLowResTime() {
+	atomic.StoreUint32(&lowResTime, uint32(time.Now().Unix()))
+}
+
+func NumMutexes() int {
+	weakRefLock.Lock()
+	defer weakRefLock.Unlock()
+	return len(weakRefs) - len(weakRefFree)
+}
+
+// ScanTrackedLocks check all lock trackers
+func ScanTrackedLocks(threshold time.Duration) bool {
+	minTS := uint32(time.Now().Add(-threshold).Unix())
+
+	weakRefLock.Lock()
+	defer weakRefLock.Unlock()
+	return scanTrackedLocks(weakRefs, minTS)
+}
+
+// ScanTrackedLocksP check all locker trackers in parallel
+func ScanTrackedLocksP(threshold time.Duration) bool {
+	minTS := uint32(time.Now().Add(-threshold).Unix())
+
+	weakRefLock.Lock()
+	defer weakRefLock.Unlock()
+
+	var found uint32
+
+	k := runtime.NumCPU()
+	n := (len(weakRefs) + (k - 1)) / k
+
+	var wg sync.WaitGroup
+	wg.Add(k)
+	for i := 0; i < k; i++ {
+		min := n * i
+		max := n * (i + 1)
+		go func() {
+			for _, ref := range weakRefs[min:max] {
+				if ref != 0 {
+					t := (*lockTracker)(unsafe.Pointer(ref))
+					ts := atomic.LoadUint32(&t.ts)
+					if ts <= minTS {
+						atomic.StoreUint32(&found, 1)
+						return
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	return found == 1
+}
+
+var nextScanMin int
+
+// ScanTrackedLocksI check lock trackers incrementally n at a time
+func ScanTrackedLocksI(threshold time.Duration, n int) bool {
+	if n <= 0 {
+		n = 10000
+	}
+	minTS := uint32(time.Now().Add(-threshold).Unix())
+
+	weakRefLock.Lock()
+	defer weakRefLock.Unlock()
+
+	min := nextScanMin
+	max := nextScanMin + n
+	if rl := len(weakRefs); rl <= max {
+		max = rl
+		nextScanMin = 0
+	} else {
+		nextScanMin = max
+	}
+
+	return scanTrackedLocks(weakRefs[min:max], minTS)
+}
+
+func scanTrackedLocks(refs []uintptr, minTS uint32) bool {
+	for _, ref := range weakRefs {
+		if ref != 0 {
+			t := (*lockTracker)(unsafe.Pointer(ref))
+			ts := atomic.LoadUint32(&t.ts)
+			if ts <= minTS {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type lockTracker struct {
+	ts  uint32
+	ref int
+}
+
+func (t *lockTracker) observeWait() {
+	atomic.StoreUint32(&t.ts, atomic.LoadUint32(&lowResTime))
+}
+
+func (t *lockTracker) observeLock() {
+	atomic.StoreUint32(&t.ts, math.MaxUint32)
+}
+
+func newLockTracker() *lockTracker {
+	t := &lockTracker{}
+
+	runtime.SetFinalizer(t, finalizeLockTracker)
+
+	weakRefLock.Lock()
+	defer weakRefLock.Unlock()
+
+	if fi := len(weakRefFree) - 1; fi > 0 {
+		t.ref = weakRefFree[fi]
+		weakRefs[t.ref] = uintptr((unsafe.Pointer)(t))
+		weakRefFree = weakRefFree[:fi]
+	} else {
+		t.ref = len(weakRefs)
+		weakRefs = append(weakRefs, uintptr((unsafe.Pointer)(t)))
+	}
+
+	return t
+}
+
+func finalizeLockTracker(t *lockTracker) {
+	weakRefLock.Lock()
+	defer weakRefLock.Unlock()
+
+	weakRefs[t.ref] = 0
+	weakRefFree = append(weakRefFree, t.ref)
+}
+
+var waiting lockTracker
+
+//go:linkname sync_runtime_doSpin sync.runtime_doSpin
+func sync_runtime_doSpin()
+
+//go:linkname sync_runtime_canSpin sync.runtime_canSpin
+func sync_runtime_canSpin(int) bool
+
+func lazyInitLockTracker(p **lockTracker) {
+	up := (*unsafe.Pointer)(unsafe.Pointer(p))
+	iter := 0
+	for {
+		if t := atomic.LoadPointer(up); t == nil {
+			if atomic.CompareAndSwapPointer(up, nil, (unsafe.Pointer)(&waiting)) {
+				atomic.StorePointer(up, (unsafe.Pointer)(newLockTracker()))
+				return
+			}
+		} else if t == (unsafe.Pointer)(&waiting) {
+			if sync_runtime_canSpin(iter) {
+				sync_runtime_doSpin()
+				iter++
+			} else {
+				runtime.Gosched()
+			}
+		} else {
+			return
+		}
+	}
+}
+
+type Mutex struct {
+	sync.Mutex
+	t *lockTracker
+}
+
+func (m *Mutex) Lock() {
+	lazyInitLockTracker(&m.t)
+	m.t.observeWait()
+	m.Mutex.Lock()
+	m.t.observeLock()
+}
+
+type RWMutex struct {
+	sync.RWMutex
+	t *lockTracker
+}
+
+func (m *RWMutex) Lock() {
+	lazyInitLockTracker(&m.t)
+	m.t.observeWait()
+	m.RWMutex.Lock()
+	m.t.observeLock()
+}
+
+func (m *RWMutex) RLock() {
+	lazyInitLockTracker(&m.t)
+	m.t.observeWait()
+	m.RWMutex.RLock()
+	m.t.observeLock()
+}

--- a/utils/lock_tracker.go
+++ b/utils/lock_tracker.go
@@ -88,10 +88,10 @@ var nextScanMin int
 
 // ScanTrackedLocksI check lock trackers incrementally n at a time
 func ScanTrackedLocksI(threshold time.Duration, n int) bool {
+	minTS := uint32(time.Now().Add(-threshold).Unix())
 	if n <= 0 {
 		n = 10000
 	}
-	minTS := uint32(time.Now().Add(-threshold).Unix())
 
 	weakRefLock.Lock()
 	defer weakRefLock.Unlock()

--- a/utils/lock_tracker_test.go
+++ b/utils/lock_tracker_test.go
@@ -1,0 +1,216 @@
+package utils_test
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/livekit/protocol/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func cleanupTest() {
+	runtime.GC()
+	time.Sleep(time.Millisecond)
+	utils.SyncLowResTime()
+}
+
+func TestScanTrackedLocks(t *testing.T) {
+	t.Cleanup(cleanupTest)
+	assert.False(t, utils.ScanTrackedLocks(time.Millisecond))
+
+	ms := make([]*utils.Mutex, 100)
+	for i := range ms {
+		m := &utils.Mutex{}
+		m.Lock()
+		m.Unlock()
+		ms[i] = m
+	}
+
+	go func() {
+		ms[50].Lock()
+		ms[50].Lock()
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	assert.True(t, utils.ScanTrackedLocks(time.Millisecond))
+
+	ms[50].Unlock()
+}
+
+func TestMutexFinalizer(t *testing.T) {
+	cleanupTest()
+	assert.Equal(t, 0, utils.NumMutexes())
+
+	go func() {
+		m := &utils.Mutex{}
+		m.Lock()
+		go func() {
+			m.Unlock()
+		}()
+		assert.Equal(t, 1, utils.NumMutexes())
+	}()
+
+	time.Sleep(time.Millisecond)
+	cleanupTest()
+
+	assert.Equal(t, 0, utils.NumMutexes())
+}
+
+func TestEmbeddedMutex(t *testing.T) {
+	t.Cleanup(cleanupTest)
+
+	foo := struct{ m utils.Mutex }{}
+	foo.m.Lock()
+	foo.m.Unlock()
+
+	bar := struct{ utils.Mutex }{}
+	bar.Lock()
+	bar.Unlock()
+}
+
+func TestContestedGlobalLock(t *testing.T) {
+	t.Cleanup(cleanupTest)
+
+	ms := make([]*utils.Mutex, 1000000)
+	for i := range ms {
+		m := &utils.Mutex{}
+		m.Lock()
+		m.Unlock()
+		ms[i] = m
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				utils.ScanTrackedLocks(time.Minute)
+				wg.Done()
+			}()
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			var m utils.Mutex
+			wg.Add(3)
+			for i := 0; i < 3; i++ {
+				go func() {
+					m.Lock()
+					m.Unlock()
+					wg.Done()
+				}()
+			}
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+func BenchmarkLockTracker(b *testing.B) {
+	b.Run("wrapped mutex", func(b *testing.B) {
+		var m utils.Mutex
+		for i := 0; i < b.N; i++ {
+			m.Lock()
+			m.Unlock()
+		}
+	})
+	b.Run("native mutex", func(b *testing.B) {
+		var m sync.Mutex
+		for i := 0; i < b.N; i++ {
+			m.Lock()
+			m.Unlock()
+		}
+	})
+	b.Run("wrapped rwmutex", func(b *testing.B) {
+		var m utils.RWMutex
+		for i := 0; i < b.N; i++ {
+			m.Lock()
+			m.Unlock()
+		}
+	})
+	b.Run("native rwmutex", func(b *testing.B) {
+		var m sync.RWMutex
+		for i := 0; i < b.N; i++ {
+			m.Lock()
+			m.Unlock()
+		}
+	})
+
+	b.Run("wrapped mutex init", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var m utils.Mutex
+			m.Lock()
+			m.Unlock()
+		}
+	})
+	b.Run("native mutex init", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var m sync.Mutex
+			m.Lock()
+			m.Unlock()
+		}
+	})
+	b.Run("wrapped rwmutex init", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var m utils.RWMutex
+			m.Lock()
+			m.Unlock()
+		}
+	})
+	b.Run("native rwmutex init", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var m sync.RWMutex
+			m.Lock()
+			m.Unlock()
+		}
+	})
+}
+
+func BenchmarkGetBlocked(b *testing.B) {
+	for n := 100; n <= 1000000; n *= 100 {
+		n := n
+		b.Run(fmt.Sprintf("serial/%d", n), func(b *testing.B) {
+			cleanupTest()
+
+			ms := make([]*utils.Mutex, n)
+			for i := range ms {
+				m := &utils.Mutex{}
+				m.Lock()
+				m.Unlock()
+				ms[i] = m
+			}
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				utils.ScanTrackedLocks(time.Minute)
+			}
+		})
+
+		b.Run(fmt.Sprintf("parallel/%d", n), func(b *testing.B) {
+			cleanupTest()
+
+			ms := make([]*utils.Mutex, n)
+			for i := range ms {
+				m := &utils.Mutex{}
+				m.Lock()
+				m.Unlock()
+				ms[i] = m
+			}
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				utils.ScanTrackedLocksP(time.Minute)
+			}
+		})
+	}
+}

--- a/utils/lock_tracker_test.go
+++ b/utils/lock_tracker_test.go
@@ -17,6 +17,8 @@ func cleanupTest() {
 	utils.SyncLowResTime()
 }
 
+func noop() {}
+
 func TestScanTrackedLocks(t *testing.T) {
 	t.Cleanup(cleanupTest)
 	assert.False(t, utils.ScanTrackedLocks(time.Millisecond))
@@ -25,6 +27,7 @@ func TestScanTrackedLocks(t *testing.T) {
 	for i := range ms {
 		m := &utils.Mutex{}
 		m.Lock()
+		noop()
 		m.Unlock()
 		ms[i] = m
 	}
@@ -64,10 +67,12 @@ func TestEmbeddedMutex(t *testing.T) {
 
 	foo := struct{ m utils.Mutex }{}
 	foo.m.Lock()
+	noop()
 	foo.m.Unlock()
 
 	bar := struct{ utils.Mutex }{}
 	bar.Lock()
+	noop()
 	bar.Unlock()
 }
 
@@ -78,6 +83,7 @@ func TestContestedGlobalLock(t *testing.T) {
 	for i := range ms {
 		m := &utils.Mutex{}
 		m.Lock()
+		noop()
 		m.Unlock()
 		ms[i] = m
 	}
@@ -103,6 +109,7 @@ func TestContestedGlobalLock(t *testing.T) {
 			for i := 0; i < 3; i++ {
 				go func() {
 					m.Lock()
+					noop()
 					m.Unlock()
 					wg.Done()
 				}()
@@ -119,6 +126,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		var m utils.Mutex
 		for i := 0; i < b.N; i++ {
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -126,6 +134,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		var m sync.Mutex
 		for i := 0; i < b.N; i++ {
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -133,6 +142,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		var m utils.RWMutex
 		for i := 0; i < b.N; i++ {
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -140,6 +150,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		var m sync.RWMutex
 		for i := 0; i < b.N; i++ {
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -148,6 +159,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var m utils.Mutex
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -155,6 +167,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var m sync.Mutex
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -162,6 +175,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var m utils.RWMutex
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -169,6 +183,7 @@ func BenchmarkLockTracker(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var m sync.RWMutex
 			m.Lock()
+			noop()
 			m.Unlock()
 		}
 	})
@@ -184,6 +199,7 @@ func BenchmarkGetBlocked(b *testing.B) {
 			for i := range ms {
 				m := &utils.Mutex{}
 				m.Lock()
+				noop()
 				m.Unlock()
 				ms[i] = m
 			}
@@ -202,6 +218,7 @@ func BenchmarkGetBlocked(b *testing.B) {
 			for i := range ms {
 				m := &utils.Mutex{}
 				m.Lock()
+				noop()
 				m.Unlock()
 				ms[i] = m
 			}


### PR DESCRIPTION
track the time locks are attempted/granted so we can scan for hung locks without stopping the world to print stack dumps