### PR TITLE
add toggle for lock tracking

### DIFF
--- a/utils/lock_tracker_test.go
+++ b/utils/lock_tracker_test.go
@@ -11,10 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	utils.EnableLockTracker()
+}
+
 func cleanupTest() {
 	runtime.GC()
 	time.Sleep(time.Millisecond)
-	utils.SyncLowResTime()
 }
 
 func noop() {}


### PR DESCRIPTION
we only need this in cloud but this change touches the participant locks in livekit so this makes it free for oss users
```
BenchmarkLockTracker/wrapped_mutex
BenchmarkLockTracker/wrapped_mutex-10         	79021450	        13.52 ns/op	       0 B/op	       0 allocs/op
BenchmarkLockTracker/native_mutex
BenchmarkLockTracker/native_mutex-10          	89654545	        13.39 ns/op	       0 B/op	       0 allocs/op
BenchmarkLockTracker/wrapped_rwmutex
BenchmarkLockTracker/wrapped_rwmutex-10       	64433134	        18.66 ns/op	       0 B/op	       0 allocs/op
BenchmarkLockTracker/native_rwmutex
BenchmarkLockTracker/native_rwmutex-10        	65227876	        18.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkLockTracker/wrapped_mutex_init
BenchmarkLockTracker/wrapped_mutex_init-10    	58114779	        20.57 ns/op	      16 B/op	       1 allocs/op
BenchmarkLockTracker/native_mutex_init
BenchmarkLockTracker/native_mutex_init-10     	76161259	        15.75 ns/op	       8 B/op	       1 allocs/op
BenchmarkLockTracker/wrapped_rwmutex_init
BenchmarkLockTracker/wrapped_rwmutex_init-10  	44082667	        26.47 ns/op	      32 B/op	       1 allocs/op
BenchmarkLockTracker/native_rwmutex_init
BenchmarkLockTracker/native_rwmutex_init-10   	47045139	        25.66 ns/op	      24 B/op	       1 allocs/op
```