### PR TITLE
add norace directive to scanTrackedLocks

### DIFF
--- a/utils/lock_tracker_test.go
+++ b/utils/lock_tracker_test.go
@@ -213,24 +213,5 @@ func BenchmarkGetBlocked(b *testing.B) {
 				utils.ScanTrackedLocks(time.Minute)
 			}
 		})
-
-		b.Run(fmt.Sprintf("parallel/%d", n), func(b *testing.B) {
-			cleanupTest()
-
-			ms := make([]*utils.Mutex, n)
-			for i := range ms {
-				m := &utils.Mutex{}
-				m.Lock()
-				noop()
-				m.Unlock()
-				ms[i] = m
-			}
-
-			b.ResetTimer()
-
-			for i := 0; i < b.N; i++ {
-				utils.ScanTrackedLocksP(time.Minute)
-			}
-		})
 	}
 }


### PR DESCRIPTION
race detector panics if we access an object that is being gced. it is safe here because until the finalizer finishes the `lockTracker` won't be freed and finalizer and scan functions all hold `weakRefLock`.

also deleting the parallel implementation of scan because it complicates this issue and incremental scanning seems preferable given the small number of locks and latency requirements.