### PR TITLE
move TimedVersion from livekit

### DIFF
--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -102,9 +102,13 @@ func (t *TimedVersion) Update(other *TimedVersion) {
 	}
 }
 
-func (t *TimedVersion) Set(other *TimedVersion) {
+func (t *TimedVersion) Store(other *TimedVersion) {
 	ov := atomic.LoadUint64((*uint64)(other))
 	atomic.StoreUint64((*uint64)(t), ov)
+}
+
+func (t *TimedVersion) Load() TimedVersion {
+	return TimedVersion(atomic.LoadUint64((*uint64)(t)))
 }
 
 func (t *TimedVersion) After(other *TimedVersion) bool {

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -1,0 +1,138 @@
+package utils
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+	_ "unsafe"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+//go:linkname nanotime1 runtime.nanotime1
+func nanotime1() int64
+
+//go:linkname usleep runtime.usleep
+func usleep(usec uint32)
+
+const tickBits uint64 = 16
+const timeMask uint64 = 0xffffffffffff0000
+const tickMask = ^timeMask
+const timeGranularity = 1000
+
+var epoch = time.Now().UnixNano() - nanotime1()
+
+type TimedVersionGenerator interface {
+	New() *TimedVersion
+	Next() TimedVersion
+}
+
+func timedVersionComponents(v TimedVersion) (ts int64, ticks int32) {
+	return int64(uint64(v)>>tickBits) + epoch/timeGranularity, int32(uint64(v) & tickMask)
+}
+
+func timedVersionFromComponents(ts int64, ticks int32) TimedVersion {
+	return TimedVersion(uint64(ts-epoch/timeGranularity)<<tickBits | uint64(ticks))
+}
+
+type timedVersionGenerator uint64
+
+func NewDefaultTimedVersionGenerator() TimedVersionGenerator {
+	return new(timedVersionGenerator)
+}
+
+func (g *timedVersionGenerator) New() *TimedVersion {
+	v := g.Next()
+	return &v
+}
+
+func (g *timedVersionGenerator) Next() TimedVersion {
+	var next uint64
+	for {
+		prev := atomic.LoadUint64((*uint64)(g))
+		next = uint64(nanotime1()) / timeGranularity << tickBits
+
+		// if the version timestamp and next timestamp match increment the ticks
+		if prev&timeMask == next {
+			// if incrementing the ticks would overflow the version sleep for a
+			// microsecond then try again
+			if prev&tickMask == tickMask {
+				usleep(1)
+				continue
+			}
+			next = prev + 1
+		}
+		if atomic.CompareAndSwapUint64((*uint64)(g), prev, next) {
+			break
+		}
+	}
+	return TimedVersion(next)
+}
+
+type TimedVersion uint64
+
+func NewTimedVersionFromProto(proto *livekit.TimedVersion) *TimedVersion {
+	v := timedVersionFromComponents(proto.UnixMicro, proto.Ticks)
+	return &v
+}
+
+func NewTimedVersionFromTime(t time.Time) *TimedVersion {
+	v := timedVersionFromComponents(t.UnixMicro(), 0)
+	return &v
+}
+
+func TimedVersionFromProto(proto *livekit.TimedVersion) TimedVersion {
+	return timedVersionFromComponents(proto.UnixMicro, proto.Ticks)
+}
+
+func TimedVersionFromTime(t time.Time) TimedVersion {
+	return timedVersionFromComponents(t.UnixMicro(), 0)
+}
+
+func (t *TimedVersion) Update(other *TimedVersion) {
+	ov := atomic.LoadUint64((*uint64)(other))
+	for {
+		prev := atomic.LoadUint64((*uint64)(t))
+		if ov < prev {
+			return
+		}
+		if atomic.CompareAndSwapUint64((*uint64)(t), prev, ov) {
+			break
+		}
+	}
+}
+
+func (t *TimedVersion) Set(other *TimedVersion) {
+	ov := atomic.LoadUint64((*uint64)(other))
+	atomic.StoreUint64((*uint64)(t), ov)
+}
+
+func (t *TimedVersion) After(other *TimedVersion) bool {
+	ov := atomic.LoadUint64((*uint64)(other))
+	return atomic.LoadUint64((*uint64)(t)) > ov
+}
+
+func (t *TimedVersion) Compare(other *TimedVersion) int {
+	ov := atomic.LoadUint64((*uint64)(other))
+	v := atomic.LoadUint64((*uint64)(t))
+	if v < ov {
+		return -1
+	}
+	if v == ov {
+		return 0
+	}
+	return 1
+}
+
+func (t *TimedVersion) ToProto() *livekit.TimedVersion {
+	ts, ticks := timedVersionComponents(TimedVersion(atomic.LoadUint64((*uint64)(t))))
+	return &livekit.TimedVersion{
+		UnixMicro: ts,
+		Ticks:     ticks,
+	}
+}
+
+func (t *TimedVersion) String() string {
+	ts, ticks := timedVersionComponents(TimedVersion(atomic.LoadUint64((*uint64)(t))))
+	return fmt.Sprintf("%d.%d", ts, ticks)
+}

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -15,6 +15,8 @@ func nanotime1() int64
 //go:linkname usleep runtime.usleep
 func usleep(usec uint32)
 
+type nocmp [0]func()
+
 const tickBits uint64 = 16
 const tickMask uint64 = 0xffff
 const timeMask = ^tickMask
@@ -36,6 +38,8 @@ func timedVersionFromComponents(ts int64, ticks int32) TimedVersion {
 }
 
 type timedVersionGenerator struct {
+	_ nocmp // prevent comparison
+
 	v uint64
 }
 
@@ -72,7 +76,8 @@ func (g *timedVersionGenerator) Next() TimedVersion {
 }
 
 type TimedVersion struct {
-	_ [0]func() // prevent comparison
+	_ nocmp // prevent comparison
+
 	v uint64
 }
 

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -16,8 +16,8 @@ func nanotime1() int64
 func usleep(usec uint32)
 
 const tickBits uint64 = 16
-const timeMask uint64 = 0xffffffffffff0000
-const tickMask = ^timeMask
+const tickMask uint64 = 0xffff
+const timeMask = ^tickMask
 const timeGranularity = 1000
 
 var epoch = time.Now().UnixNano() - nanotime1()

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -4,20 +4,13 @@ import (
 	"fmt"
 	"sync"
 	"time"
-	_ "unsafe" // required for linkname
 
 	"go.uber.org/atomic"
 
 	"github.com/livekit/protocol/livekit"
 )
 
-//go:linkname nanotime1 runtime.nanotime1
-func nanotime1() int64
-
-//go:linkname usleep runtime.usleep
-func usleep(usec uint32)
-
-const tickBits uint64 = 12
+const tickBits uint64 = 13
 const tickMask uint64 = (1 << tickBits) - 1
 
 var epoch = time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC).UnixMicro()
@@ -64,7 +57,7 @@ func (g *timedVersionGenerator) Next() TimedVersion {
 			// if incrementing the ticks would overflow the version sleep for a
 			// microsecond then try again.
 			if g.ticks == tickMask {
-				usleep(1)
+				time.Sleep(time.Microsecond)
 				now = time.Now().UnixMicro() - epoch
 				continue
 			}

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -21,7 +21,7 @@ const tickMask uint64 = 0xffff
 const timeMask = ^tickMask
 const timeGranularity = 1000
 
-var epoch = time.Now().UnixNano() - nanotime1()
+var epoch = (time.Now().UnixNano() - nanotime1()) / timeGranularity
 
 type TimedVersionGenerator interface {
 	New() *TimedVersion
@@ -29,11 +29,11 @@ type TimedVersionGenerator interface {
 }
 
 func timedVersionComponents(v uint64) (ts int64, ticks int32) {
-	return int64(v>>tickBits) + epoch/timeGranularity, int32(v & tickMask)
+	return int64(v>>tickBits) + epoch, int32(v & tickMask)
 }
 
 func timedVersionFromComponents(ts int64, ticks int32) TimedVersion {
-	return TimedVersion{v: *atomic.NewUint64(uint64(ts-epoch/timeGranularity)<<tickBits | uint64(ticks))}
+	return TimedVersion{v: *atomic.NewUint64(uint64(ts-epoch)<<tickBits | uint64(ticks))}
 }
 
 type timedVersionGenerator struct {

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -21,7 +21,8 @@ const tickMask uint64 = 0xffff
 const timeMask = ^tickMask
 const timeGranularity = 1000
 
-var epoch = (time.Now().UnixNano() - nanotime1()) / timeGranularity
+var epochNanos = nanotime1()
+var epoch = time.Now().UnixNano() / timeGranularity
 
 type TimedVersionGenerator interface {
 	New() *TimedVersion
@@ -53,7 +54,7 @@ func (g *timedVersionGenerator) Next() TimedVersion {
 	var next uint64
 	for {
 		prev := g.v.Load()
-		next = uint64(nanotime1()) / timeGranularity << tickBits
+		next = uint64(nanotime1()-epochNanos) / timeGranularity << tickBits
 
 		// if the version timestamp and next timestamp match increment the ticks
 		if prev&timeMask == next {

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -22,7 +22,7 @@ const timeMask = ^tickMask
 const timeGranularity = 1000
 
 var epochNanos = nanotime1()
-var epoch = time.Now().UnixNano() / timeGranularity
+var epochMicros = time.Now().UnixNano() / timeGranularity
 
 type TimedVersionGenerator interface {
 	New() *TimedVersion
@@ -30,11 +30,11 @@ type TimedVersionGenerator interface {
 }
 
 func timedVersionComponents(v uint64) (ts int64, ticks int32) {
-	return int64(v>>tickBits) + epoch, int32(v & tickMask)
+	return int64(v>>tickBits) + epochMicros, int32(v & tickMask)
 }
 
 func timedVersionFromComponents(ts int64, ticks int32) TimedVersion {
-	return TimedVersion{v: *atomic.NewUint64(uint64(ts-epoch)<<tickBits | uint64(ticks))}
+	return TimedVersion{v: *atomic.NewUint64(uint64(ts-epochMicros)<<tickBits | uint64(ticks))}
 }
 
 type timedVersionGenerator struct {

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"time"
-	_ "unsafe"
+	_ "unsafe" // required for linkname
 
 	"github.com/livekit/protocol/livekit"
 )

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -103,7 +103,7 @@ func (t *TimedVersion) Update(other *TimedVersion) {
 	ov := atomic.LoadUint64(&other.v)
 	for {
 		prev := atomic.LoadUint64(&t.v)
-		if ov < prev {
+		if ov <= prev {
 			return
 		}
 		if atomic.CompareAndSwapUint64(&t.v, prev, ov) {

--- a/utils/timed_version.go
+++ b/utils/timed_version.go
@@ -116,8 +116,7 @@ func (t *TimedVersion) Load() TimedVersion {
 }
 
 func (t *TimedVersion) After(other *TimedVersion) bool {
-	ov := other.v.Load()
-	return t.v.Load() > ov
+	return t.v.Load() > other.v.Load()
 }
 
 func (t *TimedVersion) Compare(other *TimedVersion) int {

--- a/utils/timed_version_test.go
+++ b/utils/timed_version_test.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimedVersion(t *testing.T) {
@@ -13,24 +13,24 @@ func TestTimedVersion(t *testing.T) {
 		tv2 := gen.New()
 		tv3 := gen.New()
 
-		assert.True(t, tv3.After(tv1))
-		assert.True(t, tv3.After(tv2))
-		assert.True(t, tv2.After(tv1))
+		require.True(t, tv3.After(tv1))
+		require.True(t, tv3.After(tv2))
+		require.True(t, tv2.After(tv1))
 
 		tv2.Update(tv3)
-		assert.True(t, tv2.After(tv1))
+		require.True(t, tv2.After(tv1))
 		// tv3 and tv2 are equivalent after update
-		assert.False(t, tv3.After(tv2))
+		require.False(t, tv3.After(tv2))
 
-		assert.Equal(t, 0, tv1.Compare(tv1))
-		assert.Equal(t, -1, tv1.Compare(tv2))
-		assert.Equal(t, 1, tv2.Compare(tv1))
+		require.Equal(t, 0, tv1.Compare(tv1))
+		require.Equal(t, -1, tv1.Compare(tv2))
+		require.Equal(t, 1, tv2.Compare(tv1))
 	})
 
 	t.Run("protobuf roundtrip", func(t *testing.T) {
 		gen := NewDefaultTimedVersionGenerator()
 		tv1 := gen.New()
 		tv2 := NewTimedVersionFromProto(tv1.ToProto())
-		assert.Equal(t, tv1.v.Load(), tv2.v.Load())
+		require.Equal(t, tv1.v.Load(), tv2.v.Load())
 	})
 }

--- a/utils/timed_version_test.go
+++ b/utils/timed_version_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimedVersion(t *testing.T) {
+	t.Run("timed versions are monotonic and comparable", func(t *testing.T) {
+		gen := NewDefaultTimedVersionGenerator()
+		tv1 := gen.New()
+		tv2 := gen.New()
+		tv3 := gen.New()
+
+		assert.True(t, tv3.After(tv1))
+		assert.True(t, tv3.After(tv2))
+		assert.True(t, tv2.After(tv1))
+
+		tv2.Update(tv3)
+		assert.True(t, tv2.After(tv1))
+		// tv3 and tv2 are equivalent after update
+		assert.False(t, tv3.After(tv2))
+
+		assert.Equal(t, 0, tv1.Compare(tv1))
+		assert.Equal(t, -1, tv1.Compare(tv2))
+		assert.Equal(t, 1, tv2.Compare(tv1))
+	})
+
+	t.Run("protobuf roundtrip", func(t *testing.T) {
+		gen := NewDefaultTimedVersionGenerator()
+		tv1 := gen.New()
+		tv2 := NewTimedVersionFromProto(tv1.ToProto())
+		require.Equal(t, *tv1, *tv2)
+	})
+
+	t.Run("timed version protobufs are backward compatible", func(t *testing.T) {
+		gen := NewDefaultTimedVersionGenerator()
+		tv := gen.New().ToProto()
+		now := time.Now()
+		d := tv.UnixMicro - now.UnixMicro()
+
+		// +/- 1 millisecond
+		require.Less(t, -int64(1000), d)
+		require.Greater(t, int64(1000), d)
+	})
+}

--- a/utils/timed_version_test.go
+++ b/utils/timed_version_test.go
@@ -2,10 +2,8 @@ package utils
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTimedVersion(t *testing.T) {
@@ -33,17 +31,6 @@ func TestTimedVersion(t *testing.T) {
 		gen := NewDefaultTimedVersionGenerator()
 		tv1 := gen.New()
 		tv2 := NewTimedVersionFromProto(tv1.ToProto())
-		require.Equal(t, *tv1, *tv2)
-	})
-
-	t.Run("timed version protobufs are backward compatible", func(t *testing.T) {
-		gen := NewDefaultTimedVersionGenerator()
-		tv := gen.New().ToProto()
-		now := time.Now()
-		d := tv.UnixMicro - now.UnixMicro()
-
-		// +/- 1 millisecond
-		require.Less(t, -int64(1000), d)
-		require.Greater(t, int64(1000), d)
+		assert.Equal(t, tv1.v.Load(), tv2.v.Load())
 	})
 }


### PR DESCRIPTION
this is backward compatible with the existing implementations but can work without allocating (>10% of allocated objects in syncstore are TimedVersions)