### PR TITLE
Fix incorrectly wiping out dropped count

### DIFF
--- a/webhook/url_notifier.go
+++ b/webhook/url_notifier.go
@@ -133,7 +133,7 @@ func (n *URLNotifier) processQueue() {
 	for event := n.nextItem(); event != nil && !n.fuse.IsBroken(); event = n.nextItem() {
 		if err := n.send(event); err != nil {
 			n.params.Logger.Warnw("failed to send webhook", err, "url", n.params.URL, "event", event.Event)
-			n.dropped.Store(event.NumDropped + 1)
+			n.dropped.Add(event.NumDropped + 1)
 		}
 	}
 }


### PR DESCRIPTION
It's possible to have dropped more messages during the retry attempt.