### PR TITLE
fix numCPU (open /sys/fs/cgroup/cpu.max: no such file or directory)

### DIFF
--- a/utils/cpu_linux.go
+++ b/utils/cpu_linux.go
@@ -187,6 +187,10 @@ func (cg *cpuInfoGetterV2) getTotalCPUTime() (int64, error) {
 func (cg *cpuInfoGetterV2) numCPU() (int, error) {
 	b, err := os.ReadFile(numCPUPathV2)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			//File may not exist in case of no quota
+			return runtime.NumCPU(), nil
+		}
 		return 0, err
 	}
 


### PR DESCRIPTION
If we try to run ingress app on Debian 11 we will get an error:
livekit-ingress[68889]: open /sys/fs/cgroup/cpu.max: no such file or directory

this merge request fix it

https://github.com/livekit/ingress/issues/61