### PR TITLE
Timed aggregator.

### DIFF
--- a/utils/timed_aggregator.go
+++ b/utils/timed_aggregator.go
@@ -1,0 +1,173 @@
+package utils
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ------------------------------------------------
+
+var (
+	errAnachronousSample = errors.New("anachronous sample")
+)
+
+// ------------------------------------------------
+
+type number interface {
+	int64 | float64
+}
+
+type TimedAggregatorParams struct {
+	CapNegativeValues bool
+}
+
+type TimedAggregator[T number] struct {
+	params TimedAggregatorParams
+
+	lock              sync.RWMutex
+	lastSample        T
+	lastSampleAt      time.Time
+	aggregate         T
+	aggregateDuration time.Duration
+}
+
+func NewTimedAggregator[T number](params TimedAggregatorParams) *TimedAggregator[T] {
+	return &TimedAggregator[T]{
+		params: params,
+	}
+}
+
+func (t *TimedAggregator[T]) AddSampleAt(val T, at time.Time) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if val < 0 && t.params.CapNegativeValues {
+		val = 0
+	}
+
+	return t.addSampleAtLocked(val, at)
+}
+
+func (t *TimedAggregator[T]) AddSample(val T) error {
+	return t.AddSampleAt(val, time.Now())
+}
+
+func (t *TimedAggregator[T]) addSampleAtLocked(val T, at time.Time) error {
+	var sinceLast time.Duration
+	if !t.lastSampleAt.IsZero() {
+		if t.lastSampleAt.After(at) {
+			return errAnachronousSample
+		}
+
+		sinceLast = at.Sub(t.lastSampleAt)
+	}
+	lastVal := t.lastSample
+
+	t.lastSample = val
+	t.lastSampleAt = at
+
+	t.aggregate += T(sinceLast.Seconds() * float64(lastVal))
+	t.aggregateDuration += sinceLast
+	return nil
+}
+
+func (t *TimedAggregator[T]) GetAggregate() (T, time.Duration) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.aggregate, t.aggregateDuration
+}
+
+func (t *TimedAggregator[T]) GetAggregateAt(at time.Time) (T, time.Duration) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.getAggregateAtLocked(at)
+}
+
+func (t *TimedAggregator[T]) GetAggregateAndRestartAt(at time.Time) (T, time.Duration) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	aggregate, aggregateDuration := t.getAggregateAtLocked(at)
+	t.restartAtLocked(at)
+	return aggregate, aggregateDuration
+}
+
+func (t *TimedAggregator[T]) getAggregateAtLocked(at time.Time) (T, time.Duration) {
+	if !t.lastSampleAt.IsZero() {
+		// re-add last sample at given time
+		t.addSampleAtLocked(t.lastSample, at)
+	}
+
+	return t.aggregate, t.aggregateDuration
+}
+
+func (t *TimedAggregator[T]) GetAverage() float64 {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.getAverageLocked()
+}
+
+func (t *TimedAggregator[T]) GetAverageAt(at time.Time) float64 {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.getAverageAtLocked(at)
+}
+
+func (t *TimedAggregator[T]) GetAverageAndRestartAt(at time.Time) float64 {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	average := t.getAverageAtLocked(at)
+	t.restartAtLocked(at)
+	return average
+}
+
+func (t *TimedAggregator[T]) getAverageLocked() float64 {
+	seconds := t.aggregateDuration.Seconds()
+	if seconds == 0.0 {
+		return 0.0
+	}
+
+	return float64(t.aggregate) / seconds
+}
+
+func (t *TimedAggregator[T]) getAverageAtLocked(at time.Time) float64 {
+	if !t.lastSampleAt.IsZero() {
+		// re-add last sample at given time
+		t.addSampleAtLocked(t.lastSample, at)
+	}
+
+	return t.getAverageLocked()
+}
+
+func (t *TimedAggregator[T]) Reset() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.lastSample = 0
+	t.lastSampleAt = time.Time{}
+	t.aggregate = 0
+	t.aggregateDuration = 0
+}
+
+func (t *TimedAggregator[T]) RestartAt(at time.Time) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.restartAtLocked(at)
+}
+
+func (t *TimedAggregator[T]) Restart() {
+	t.RestartAt(time.Now())
+}
+
+func (t *TimedAggregator[T]) restartAtLocked(at time.Time) {
+	t.lastSampleAt = at
+	t.aggregate = 0
+	t.aggregateDuration = 0
+}

--- a/utils/timed_aggregator_test.go
+++ b/utils/timed_aggregator_test.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimedAggregator(t *testing.T) {
+	t.Run("functions", func(t *testing.T) {
+		ta := NewTimedAggregator[float64](TimedAggregatorParams{})
+
+		aggregate, aggregateDuration := ta.GetAggregate()
+		require.Equal(t, 0.0, aggregate)
+		require.Equal(t, time.Duration(0), aggregateDuration)
+		require.Equal(t, 0.0, ta.GetAverage())
+
+		now := time.Now()
+		require.NoError(t, ta.AddSampleAt(1.0, now))
+		// nothing to aggregate with just one sample
+		aggregate, aggregateDuration = ta.GetAggregate()
+		require.Equal(t, 0.0, aggregate)
+		require.Equal(t, time.Duration(0), aggregateDuration)
+		require.Equal(t, 0.0, ta.GetAverage())
+
+		require.NoError(t, ta.AddSampleAt(2.0, now.Add(500*time.Millisecond)))
+		// second sample added should make stats available
+		aggregate, aggregateDuration = ta.GetAggregate()
+		require.Equal(t, 0.5, aggregate)
+		require.Equal(t, 500*time.Millisecond, aggregateDuration)
+		require.Equal(t, 1.0, ta.GetAverage())
+
+		// cannot add anachronous sample
+		require.Error(t, errAnachronousSample, ta.AddSampleAt(10.0, now.Add(200*time.Millisecond)))
+
+		// check a bit later, last value should continue
+		// 1.0 (0.5s) +  2.0 (1.0s)
+		aggregate, aggregateDuration = ta.GetAggregateAt(now.Add(1500 * time.Millisecond))
+		require.Equal(t, 2.5, aggregate)
+		require.Equal(t, 1500*time.Millisecond, aggregateDuration)
+		require.Equal(t, 2.5/1.5, ta.GetAverage())
+
+		// another second out and restart
+		// 1.0 (0.5s) +  2.0 (2.0s)
+		aggregate, aggregateDuration = ta.GetAggregateAndRestartAt(now.Add(2500 * time.Millisecond))
+		require.Equal(t, 4.5, aggregate)
+		require.Equal(t, 2500*time.Millisecond, aggregateDuration)
+
+		// restart should have reset the aggregates
+		aggregate, aggregateDuration = ta.GetAggregate()
+		require.Equal(t, 0.0, aggregate)
+		require.Equal(t, time.Duration(0), aggregateDuration)
+		require.Equal(t, 0.0, ta.GetAverage())
+
+		// add a sample a bit later and check aggregates
+		require.NoError(t, ta.AddSampleAt(20.0, now.Add(2800*time.Millisecond)))
+		// 2.0 (0.3s) + 20.0 (0.2s)
+		aggregate, aggregateDuration = ta.GetAggregateAt(now.Add(3000 * time.Millisecond))
+		require.Equal(t, 4.6, aggregate)
+		require.Equal(t, 500*time.Millisecond, aggregateDuration)
+		require.Equal(t, 4.6/0.5, ta.GetAverage())
+
+		// get average a bit later
+		// 2.0 (0.3s) +  20.0 (0.5s)
+		require.Equal(t, float64(10.6)/float64(0.8), ta.GetAverageAt(now.Add(3300*time.Millisecond)))
+		aggregate, aggregateDuration = ta.GetAggregate()
+		require.Equal(t, 10.6, aggregate)
+		require.Equal(t, 800*time.Millisecond, aggregateDuration)
+
+		// get average and restart a bit later
+		// 2.0 (0.3s) +  20.0 (1.0s)
+		require.Equal(t, float64(20.6)/float64(1.3), ta.GetAverageAndRestartAt(now.Add(3800*time.Millisecond)))
+		// restart should have reset the aggregates
+		aggregate, aggregateDuration = ta.GetAggregate()
+		require.Equal(t, 0.0, aggregate)
+		require.Equal(t, time.Duration(0), aggregateDuration)
+
+		// add a negative value sample
+		require.NoError(t, ta.AddSampleAt(-2.0, now.Add(4000*time.Millisecond)))
+
+		// get average a bit later
+		// 20.0 (0.2s) +  -2.0 (0.5s)
+		require.Equal(t, float64(3.0)/float64(0.7), ta.GetAverageAt(now.Add(4500*time.Millisecond)))
+		aggregate, aggregateDuration = ta.GetAggregate()
+		require.Equal(t, 3.0, aggregate)
+		require.Equal(t, 700*time.Millisecond, aggregateDuration)
+	})
+
+	t.Run("negative_values", func(t *testing.T) {
+		ta := NewTimedAggregator[int64](TimedAggregatorParams{
+			CapNegativeValues: true,
+		})
+
+		now := time.Now()
+		require.NoError(t, ta.AddSampleAt(1, now))
+		require.NoError(t, ta.AddSampleAt(-1, now.Add(time.Second)))
+		require.NoError(t, ta.AddSampleAt(1, now.Add(2*time.Second)))
+
+		// 1 (1.0s) + 0 (capped value) (1.0s) + 1 (1.0s)
+		aggregate, aggregateDuration := ta.GetAggregateAt(now.Add(3 * time.Second))
+		require.Equal(t, int64(2), aggregate)
+		require.Equal(t, 3*time.Second, aggregateDuration)
+		require.Equal(t, float64(2.0)/float64(3.0), ta.GetAverage())
+	})
+}


### PR DESCRIPTION
Online aggretor over time.

Samples added aggregate (scaled by amount of time a sample has lived for) at the time of adding sample.

Can get aggregate, aggregate duration and average value later.

First use: in scorer to keep track of aggregate bandwidth, average distance from desired layer