### PR TITLE
Update ingress layer validation logic to make sure both dimensions in crease for each layer

### DIFF
--- a/ingress/validation.go
+++ b/ingress/validation.go
@@ -175,18 +175,21 @@ func ValidateVideoEncodingOptionsConsistency(options *livekit.IngressVideoEncodi
 		layersByQuality[layer.Quality] = layer
 	}
 
-	var oldLayerArea uint32
+	var oldW, oldH uint32
 	for q := livekit.VideoQuality_LOW; q <= livekit.VideoQuality_HIGH; q++ {
 		layer, ok := layersByQuality[q]
 		if !ok {
 			continue
 		}
-		layerArea := layer.Width * layer.Height
 
-		if layerArea <= oldLayerArea {
-			return NewInvalidVideoParamsError("video layers do not have increasing pixel count with increasing quality")
+		if layer.Height < oldH {
+			return NewInvalidVideoParamsError("video layers do not have increasing height with increasing quality")
 		}
-		oldLayerArea = layerArea
+		if layer.Width < oldW {
+			return NewInvalidVideoParamsError("video layers do not have increasing width with increasing quality")
+		}
+		oldW = layer.Width
+		oldH = layer.Height
 	}
 
 	return nil

--- a/ingress/validation_test.go
+++ b/ingress/validation_test.go
@@ -175,7 +175,7 @@ func TestValidateVideoOptionsConsistency(t *testing.T) {
 		},
 	}
 	err = ValidateVideoOptionsConsistency(video)
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	video.EncodingOptions.(*livekit.IngressVideoOptions_Options).Options.Layers = []*livekit.VideoLayer{
 		&livekit.VideoLayer{


### PR DESCRIPTION
This is a preamble to changing the ingress logic to boxing the input video into the layer dimension, instead of resizing to the layer dimensions regardless of aspect ratio. 

This may cause some existing ingress to stop working.