### PR TITLE
Log Pion trace level logs at Debug level.

### DIFF
--- a/logger/pionlogger/logadapter.go
+++ b/logger/pionlogger/logadapter.go
@@ -28,11 +28,11 @@ type logAdapter struct {
 }
 
 func (l *logAdapter) Trace(msg string) {
-	// ignore trace
+	l.logger.Debugw(msg)
 }
 
 func (l *logAdapter) Tracef(format string, args ...interface{}) {
-	// ignore trace
+	l.logger.Debugw(fmt.Sprintf(format, args...))
 }
 
 func (l *logAdapter) Debug(msg string) {


### PR DESCRIPTION
Trying to debug connectivity issues in a deploy.
Need Pion trace level logs to check ICE details (candidates, STUN binding request/responses, etc.). So, log pion trace at Debugw instead of ignoring it.