### PR TITLE
Add call depth to Pion logger

### DIFF
--- a/logger/pionlogger/logger.go
+++ b/logger/pionlogger/logger.go
@@ -61,7 +61,7 @@ func NewLoggerFactory(logger logger.Logger) *LoggerFactory {
 
 func (f *LoggerFactory) NewLogger(scope string) logging.LeveledLogger {
 	return &logAdapter{
-		logger:          f.logger.WithComponent("pion." + scope),
+		logger:          f.logger.WithComponent("pion." + scope).WithCallDepth(1),
 		ignoredPrefixes: pionIgnoredPrefixes[scope],
 	}
 }


### PR DESCRIPTION
Currently all pion logs are showing a caller within the logger itself, which is incorrect