### PR TITLE
generate lightweight stack traces for stuck locks

### DIFF
--- a/utils/lock_tracker.go
+++ b/utils/lock_tracker.go
@@ -17,13 +17,14 @@ package utils
 import (
 	"math"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"golang.org/x/exp/slices"
 )
 
 const lockTrackerMaxStackDepth = 16


### PR DESCRIPTION
stack traces look more or less like normal traces but without function arguments eg
```
github.com/livekit/protocol/utils.(*Mutex).Lock
	/Users/paul/projects/protocol/utils/lock_tracker.go:274
github.com/livekit/protocol/utils_test.TestFirstLockStackTrace.func1
	/Users/paul/projects/protocol/utils/lock_tracker_test.go:78
github.com/livekit/protocol/utils_test.TestFirstLockStackTrace.func1
	/Users/paul/projects/protocol/utils/lock_tracker_test.go:76
github.com/livekit/protocol/utils_test.TestFirstLockStackTrace.func1
	/Users/paul/projects/protocol/utils/lock_tracker_test.go:76
github.com/livekit/protocol/utils_test.TestFirstLockStackTrace.func2
	/Users/paul/projects/protocol/utils/lock_tracker_test.go:83
```

400ns/op... not great, not terrible

```
goos: darwin
goarch: arm64
pkg: github.com/livekit/protocol/utils
BenchmarkLockTracker
BenchmarkLockTracker/wrapped_mutex
BenchmarkLockTracker/wrapped_mutex-10         	47821888	        25.04 ns/op
BenchmarkLockTracker/wrapped_rwmutex
BenchmarkLockTracker/wrapped_rwmutex-10       	40629073	        29.66 ns/op
BenchmarkLockTracker/wrapped_mutex_init
BenchmarkLockTracker/wrapped_mutex_init-10    	 3102145	       401.5 ns/op
BenchmarkLockTracker/wrapped_rwmutex_init
BenchmarkLockTracker/wrapped_rwmutex_init-10  	 2729948	       436.9 ns/op
BenchmarkLockTracker/wrapped_mutex_+_stack_trace
BenchmarkLockTracker/wrapped_mutex_+_stack_trace-10         	 2671838	       446.7 ns/op
BenchmarkLockTracker/wrapped_rwmutex_+_stack_trace
BenchmarkLockTracker/wrapped_rwmutex_+_stack_trace-10       	 2929716	       411.0 ns/op
BenchmarkLockTracker/wrapped_mutex_init_+_stack_trace
BenchmarkLockTracker/wrapped_mutex_init_+_stack_trace-10    	 1418946	       833.5 ns/op
BenchmarkLockTracker/wrapped_rwmutex_init_+_stack_trace
BenchmarkLockTracker/wrapped_rwmutex_init_+_stack_trace-10  	 1479490	       798.2 ns/op
BenchmarkLockTracker/native_mutex
BenchmarkLockTracker/native_mutex-10                        	88702173	        13.55 ns/op
BenchmarkLockTracker/native_rwmutex
BenchmarkLockTracker/native_rwmutex-10                      	63464360	        18.57 ns/op
BenchmarkLockTracker/native_mutex_init
BenchmarkLockTracker/native_mutex_init-10                   	68792708	        17.43 ns/op
BenchmarkLockTracker/native_rwmutex_init
BenchmarkLockTracker/native_rwmutex_init-10                 	41874219	        26.63 ns/op
PASS
ok  	github.com/livekit/protocol/utils	19.003s
```