### PR TITLE
Implement exponential backoff in egress RPC client retry logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/lithammer/shortuuid/v4 v4.0.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
-	github.com/livekit/psrpc v0.5.3-0.20231213223846-bc354498735c
+	github.com/livekit/psrpc v0.5.3-0.20231213230638-40783a3497a3
 	github.com/mackerelio/go-osstat v0.2.4
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.7.0
 	github.com/pion/logging v0.2.2

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/lithammer/shortuuid/v4 v4.0.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
-	github.com/livekit/psrpc v0.5.2
+	github.com/livekit/psrpc v0.5.3-0.20231213223846-bc354498735c
 	github.com/mackerelio/go-osstat v0.2.4
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.7.0
 	github.com/pion/logging v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -66,10 +66,8 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/psrpc v0.5.3-0.20231213034606-72c092a7ae28 h1:vb558KoaxeDQ1ojLmRg+PxmNWbqa3Gy+083ECMq2C6Y=
-github.com/livekit/psrpc v0.5.3-0.20231213034606-72c092a7ae28/go.mod h1:cQjxg1oCxYHhxxv6KJH1gSvdtCHQoRZCHgPdm5N8v2g=
-github.com/livekit/psrpc v0.5.3-0.20231213223846-bc354498735c h1:tfLuE8yp8KrQydTIcyr3DktmMLs6yv+skyGskxaGQgE=
-github.com/livekit/psrpc v0.5.3-0.20231213223846-bc354498735c/go.mod h1:cQjxg1oCxYHhxxv6KJH1gSvdtCHQoRZCHgPdm5N8v2g=
+github.com/livekit/psrpc v0.5.3-0.20231213230638-40783a3497a3 h1:S77f+105Ic4JR/nOzk6jyqiUxWa9FOlyvJ3bYIseU8Q=
+github.com/livekit/psrpc v0.5.3-0.20231213230638-40783a3497a3/go.mod h1:cQjxg1oCxYHhxxv6KJH1gSvdtCHQoRZCHgPdm5N8v2g=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=
 github.com/mackerelio/go-osstat v0.2.4/go.mod h1:Zy+qzGdZs3A9cuIqmgbJvwbmLQH9dJvtio5ZjJTbdlQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,10 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/psrpc v0.5.2 h1:+MvG8Otm/J6MTg2MP/uuMbrkxOWsrj2hDhu/I1VIU1U=
-github.com/livekit/psrpc v0.5.2/go.mod h1:cQjxg1oCxYHhxxv6KJH1gSvdtCHQoRZCHgPdm5N8v2g=
+github.com/livekit/psrpc v0.5.3-0.20231213034606-72c092a7ae28 h1:vb558KoaxeDQ1ojLmRg+PxmNWbqa3Gy+083ECMq2C6Y=
+github.com/livekit/psrpc v0.5.3-0.20231213034606-72c092a7ae28/go.mod h1:cQjxg1oCxYHhxxv6KJH1gSvdtCHQoRZCHgPdm5N8v2g=
+github.com/livekit/psrpc v0.5.3-0.20231213223846-bc354498735c h1:tfLuE8yp8KrQydTIcyr3DktmMLs6yv+skyGskxaGQgE=
+github.com/livekit/psrpc v0.5.3-0.20231213223846-bc354498735c/go.mod h1:cQjxg1oCxYHhxxv6KJH1gSvdtCHQoRZCHgPdm5N8v2g=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=
 github.com/mackerelio/go-osstat v0.2.4/go.mod h1:Zy+qzGdZs3A9cuIqmgbJvwbmLQH9dJvtio5ZjJTbdlQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=

--- a/rpc/egress_client.go
+++ b/rpc/egress_client.go
@@ -73,7 +73,7 @@ func NewEgressClient(params ClientParams) (EgressClient, error) {
 
 			// backoff = base * 2 ^ (attempt - 1) * rand[1,2)
 			backoff := time.Duration(float64(backoffBase) * math.Pow(2, float64(attempt-1)) * (rand.Float64() + 1))
-			timeout = time.Duration(float64(timeout) * math.Pow(2, float64(attempt-1)) * (rand.Float64() + 1))
+			timeout = time.Duration(float64(timeout) * math.Pow(2, float64(attempt)))
 
 			return true, timeout, backoff
 		},

--- a/rpc/egress_client.go
+++ b/rpc/egress_client.go
@@ -17,6 +17,8 @@ package rpc
 import (
 	"context"
 	"errors"
+	"math"
+	"math/rand"
 	"time"
 
 	"github.com/livekit/protocol/livekit"
@@ -24,7 +26,10 @@ import (
 	"github.com/livekit/psrpc/pkg/middleware"
 )
 
-const retries = 3
+const (
+	retries     = 3
+	backoffBase = 1 * time.Second
+)
 
 type EgressClient interface {
 	EgressInternalClient
@@ -34,6 +39,16 @@ type EgressClient interface {
 type egressClient struct {
 	EgressInternalClient
 	EgressHandlerClient
+}
+
+func isErrRecoverable(err error) bool {
+	var e psrpc.Error
+	if !errors.As(err, &e) {
+		return true
+	}
+	return e.Code() == psrpc.DeadlineExceeded ||
+		e.Code() == psrpc.ResourceExhausted ||
+		e.Code() == psrpc.Unavailable
 }
 
 func NewEgressClient(params ClientParams) (EgressClient, error) {
@@ -46,17 +61,21 @@ func NewEgressClient(params ClientParams) (EgressClient, error) {
 		timeout = 10 * time.Second
 	}
 	internalOpts := append(opts, middleware.WithRPCRetries(middleware.RetryOptions{
-		MaxAttempts: params.MaxAttempts,
-		// use longer retry timeout
 		Timeout: timeout,
-		IsRecoverable: func(err error) bool {
-			var e psrpc.Error
-			if !errors.As(err, &e) {
-				return true
+		GetRetryParameters: func(err error, attempt int) (retry bool, timeout time.Duration, waitTime time.Duration) {
+			if !isErrRecoverable(err) {
+				return false, 0, 0
 			}
-			return e.Code() == psrpc.DeadlineExceeded ||
-				e.Code() == psrpc.ResourceExhausted ||
-				e.Code() == psrpc.Unavailable
+
+			if attempt >= retries {
+				return false, 0, 0
+			}
+
+			// backoff = base * 2 ^ (attempt - 1) * rand[1,2)
+			backoff := time.Duration(float64(backoffBase) * math.Pow(2, float64(attempt-1)) * (rand.Float64() + 1))
+			timeout = time.Duration(float64(timeout) * math.Pow(2, float64(attempt-1)) * (rand.Float64() + 1))
+
+			return true, timeout, backoff
 		},
 	}))
 	internalClient, err := NewEgressInternalClient(params.Bus, internalOpts...)


### PR DESCRIPTION
This uses exponential increases for both the timeout and backoff parameters. The formula is for the increase is:

`base * 2 ^ (attempt - 1) * rand[1,2)`

This means that for the different attempts, we get:

```
1: base * [1-2)
2: base * [2-4)
3: base * [4-8)
4: base * [8-16)
...
```