### PR TITLE
Return a clone of message so that internal field does not get mutated by

### DIFF
--- a/utils/protoproxy.go
+++ b/utils/protoproxy.go
@@ -88,7 +88,7 @@ func (p *ProtoProxy[T]) Updated() <-chan struct{} {
 func (p *ProtoProxy[T]) Get() T {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
-	return p.message
+	return proto.Clone(p.message).(T)
 }
 
 func (p *ProtoProxy[T]) Stop() {


### PR DESCRIPTION
some body else modifying using the reference.