### PR TITLE
Pass participant kind in the grant

### DIFF
--- a/auth/accesstoken.go
+++ b/auth/accesstoken.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
+
+	"github.com/livekit/protocol/livekit"
 )
 
 const (
@@ -52,6 +54,11 @@ func (t *AccessToken) SetValidFor(duration time.Duration) *AccessToken {
 
 func (t *AccessToken) SetName(name string) *AccessToken {
 	t.grant.Name = name
+	return t
+}
+
+func (t *AccessToken) SetKind(kind livekit.ParticipantInfo_Kind) *AccessToken {
+	t.grant.SetParticipantKind(kind)
 	return t
 }
 

--- a/auth/grants.go
+++ b/auth/grants.go
@@ -59,10 +59,19 @@ type VideoGrant struct {
 type ClaimGrants struct {
 	Identity string      `json:"-"`
 	Name     string      `json:"name,omitempty"`
+	Kind     string      `json:"kind,omitempty"`
 	Video    *VideoGrant `json:"video,omitempty"`
 	// for verifying integrity of the message body
 	Sha256   string `json:"sha256,omitempty"`
 	Metadata string `json:"metadata,omitempty"`
+}
+
+func (c *ClaimGrants) SetParticipantKind(kind livekit.ParticipantInfo_Kind) {
+	c.Kind = kindFromProto(kind)
+}
+
+func (c *ClaimGrants) GetParticipantKind() livekit.ParticipantInfo_Kind {
+	return kindToProto(c.Kind)
 }
 
 func (c *ClaimGrants) Clone() *ClaimGrants {
@@ -269,5 +278,26 @@ func sourceToProto(sourceStr string) livekit.TrackSource {
 		return livekit.TrackSource_SCREEN_SHARE_AUDIO
 	default:
 		return livekit.TrackSource_UNKNOWN
+	}
+}
+
+func kindFromProto(source livekit.ParticipantInfo_Kind) string {
+	return strings.ToLower(source.String())
+}
+
+func kindToProto(sourceStr string) livekit.ParticipantInfo_Kind {
+	switch sourceStr {
+	case "", "standard":
+		return livekit.ParticipantInfo_STANDARD
+	case "ingress":
+		return livekit.ParticipantInfo_INGRESS
+	case "egress":
+		return livekit.ParticipantInfo_EGRESS
+	case "sip":
+		return livekit.ParticipantInfo_SIP
+	case "agent":
+		return livekit.ParticipantInfo_AGENT
+	default:
+		return livekit.ParticipantInfo_STANDARD
 	}
 }

--- a/auth/grants_test.go
+++ b/auth/grants_test.go
@@ -16,9 +16,12 @@ package auth
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
 )
 
 func TestGrants(t *testing.T) {
@@ -66,6 +69,7 @@ func TestGrants(t *testing.T) {
 		grants := &ClaimGrants{
 			Identity: "identity",
 			Name:     "name",
+			Kind:     "kind",
 			Video:    video,
 			Sha256:   "sha256",
 			Metadata: "metadata",
@@ -79,4 +83,18 @@ func TestGrants(t *testing.T) {
 		require.True(t, reflect.DeepEqual(grants, clone))
 		require.True(t, reflect.DeepEqual(grants.Video, clone.Video))
 	})
+}
+
+func TestParticipantKind(t *testing.T) {
+	const kindMin, kindMax = livekit.ParticipantInfo_STANDARD, livekit.ParticipantInfo_AGENT
+	for k := kindMin; k <= kindMax; k++ {
+		k := k
+		t.Run(k.String(), func(t *testing.T) {
+			require.Equal(t, k, kindToProto(kindFromProto(k)))
+		})
+	}
+	const kindNext = kindMax + 1
+	if _, err := strconv.Atoi(kindNext.String()); err != nil {
+		t.Errorf("Please update kindMax to match protobuf. Missing value: %s", kindNext)
+	}
 }

--- a/egress/token.go
+++ b/egress/token.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/livekit/protocol/auth"
+	"github.com/livekit/protocol/livekit"
 )
 
 func BuildEgressToken(egressID, apiKey, secret, roomName string) (string, error) {
@@ -36,6 +37,7 @@ func BuildEgressToken(egressID, apiKey, secret, roomName string) (string, error)
 	at := auth.NewAccessToken(apiKey, secret).
 		AddGrant(grant).
 		SetIdentity(egressID).
+		SetKind(livekit.ParticipantInfo_EGRESS).
 		SetValidFor(24 * time.Hour)
 
 	return at.ToJWT()

--- a/sip/token.go
+++ b/sip/token.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ingress
+package sip
 
 import (
 	"time"
@@ -21,21 +21,18 @@ import (
 	"github.com/livekit/protocol/livekit"
 )
 
-func BuildIngressToken(apiKey, secret, roomName, participantIdentity, participantName string) (string, error) {
-	f := false
+func BuildSIPToken(apiKey, secret, roomName, participantIdentity, participantName string) (string, error) {
 	t := true
-	grant := &auth.VideoGrant{
-		RoomJoin:     true,
-		Room:         roomName,
-		CanSubscribe: &f,
-		CanPublish:   &t,
-	}
-
 	at := auth.NewAccessToken(apiKey, secret).
-		AddGrant(grant).
+		AddGrant(&auth.VideoGrant{
+			RoomJoin:     true,
+			Room:         roomName,
+			CanSubscribe: &t,
+			CanPublish:   &t,
+		}).
 		SetIdentity(participantIdentity).
 		SetName(participantName).
-		SetKind(livekit.ParticipantInfo_INGRESS).
+		SetKind(livekit.ParticipantInfo_SIP).
 		SetValidFor(24 * time.Hour)
 
 	return at.ToJWT()


### PR DESCRIPTION
Follow up for #542. Pass the participant kind in the auth grant.

Ingress/Egress will automatically start receiving new tokens, while SIP will need to be updated to use the new helper for building the token. 