### PR TITLE
Null CPU monitor for use on other platforms than linux/darwin

### DIFF
--- a/utils/cpu_darwin.go
+++ b/utils/cpu_darwin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !linux
+//go:build darwin
 
 package utils
 

--- a/utils/cpu_null.go
+++ b/utils/cpu_null.go
@@ -1,0 +1,41 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !(linux || darwin)
+
+package utils
+
+import (
+	"github.com/livekit/protocol/logger"
+	"github.com/prometheus/procfs"
+)
+
+type nullStatCPUMonitor int
+
+func (p *nullStatCPUMonitor) getCPUIdle() (float64, error) {
+	return 0, nil
+}
+
+func (p *nullStatCPUMonitor) numCPU() float64 {
+	return 1
+}
+func newPlatformCPUMonitor() (platformCPUMonitor, error) {
+	logger.Errorw("CPU monitoring unsupported on current platform. Server capacity management will be disabled", nil)
+
+	return newNullCPUMonitor()
+}
+
+func getHostCPUCount(fs procfs.FS) (float64, error) {
+	return 1, nil
+}

--- a/utils/cpu_null.go
+++ b/utils/cpu_null.go
@@ -17,25 +17,27 @@
 package utils
 
 import (
+	"runtime"
+
 	"github.com/livekit/protocol/logger"
 	"github.com/prometheus/procfs"
 )
 
-type nullStatCPUMonitor int
+type nullStatCPUMonitor struct{}
 
 func (p *nullStatCPUMonitor) getCPUIdle() (float64, error) {
-	return 0, nil
+	return float64(runtime.NumCPU()), nil
 }
 
 func (p *nullStatCPUMonitor) numCPU() float64 {
-	return 1
+	return float64(runtime.NumCPU())
 }
 func newPlatformCPUMonitor() (platformCPUMonitor, error) {
 	logger.Errorw("CPU monitoring unsupported on current platform. Server capacity management will be disabled", nil)
 
-	return newNullCPUMonitor()
+	return &nullStatCPUMonitor{}, nil
 }
 
 func getHostCPUCount(fs procfs.FS) (float64, error) {
-	return 1, nil
+	return float64(runtime.NumCPU()), nil
 }


### PR DESCRIPTION
go-osstat only supports reporting CPU usage on linux and Darwin. We do not use it on linux, so create null cpu monitor for use on all platforms other than linux and Darwin. Display a warning to report that resource management is not supported.