### PR TITLE
initialize lock tracker timestamp

### DIFF
--- a/utils/lock_tracker.go
+++ b/utils/lock_tracker.go
@@ -204,6 +204,7 @@ func (t *lockTracker) trackUnlock() {
 func newLockTracker() *lockTracker {
 	t := &lockTracker{
 		stack: make([]uintptr, lockTrackerMaxStackDepth),
+		ts:    math.MaxUint32,
 	}
 
 	runtime.SetFinalizer(t, finalizeLockTracker)


### PR DESCRIPTION
this is set during unlock but not during init so new locks can race with lock scanning