### PR TITLE
reuse zap logger stderr lock

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -271,7 +271,7 @@ func (l *ZapLogger) WithComponent(component string) Logger {
 
 func (l *ZapLogger) WithCallDepth(depth int) Logger {
 	dup := *l
-	dup.zap.WithOptions(zap.AddCallerSkip(depth))
+	dup.zap = dup.zap.WithOptions(zap.AddCallerSkip(depth))
 	return &dup
 }
 

--- a/logger/zaputil/deferrer.go
+++ b/logger/zaputil/deferrer.go
@@ -102,9 +102,6 @@ type deferredValueCore struct {
 func NewDeferredValueCore(core zapcore.Core, def *Deferrer) zapcore.Core {
 	def.mu.Lock()
 	defer def.mu.Unlock()
-	if def.ready {
-		return core.With(def.fields)
-	}
 	return &deferredValueCore{core, def}
 }
 


### PR DESCRIPTION
zap allocates a locked wrapper around stderr that gets reused when deriving loggers using `WithOptions`. by using `New` to construct our derived loggers we were losing this optimization. we can use `WrapCore` to smuggle our derived zap core into a derived zap logger to fix this...