### PR TITLE
Fix script name typo

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
     { "repo": "livekit/protocol" }
   ],
   "commit": false,
-  "fixed": [["livekit-protocol", "@livekit/protocol"]],
+  "fixed": [["github.com/livekit/protocol", "@livekit/protocol"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
     { "repo": "livekit/protocol" }
   ],
   "commit": false,
-  "fixed": [["github.com/livekit/protocol", "@livekit/protocol"]],
+  "fixed": [["livekit-protocol", "@livekit/protocol"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.10.1",
   "scripts": {
     "changeset": "changeset",
-    "publish:ci": "pnpm --filter @livekit/protocol run build && changeset publish"
+    "ci:publish": "pnpm --filter @livekit/protocol run build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "livekit-protocol",
+  "name": "github.com/livekit/protocol",
   "private": true,
   "version": "1.10.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github.com/livekit/protocol",
+  "name": "livekit-protocol",
   "private": true,
   "version": "1.10.1",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - "packages/javascript"
-  - "./"
+  - "."


### PR DESCRIPTION
the github action tries to run `ci:publish`, but the package.json defined it as `publish:ci` previously.