### PR TITLE
Install protoc in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: pnpm/action-setup@v2
         with:
           version: 8


### PR DESCRIPTION
release action is currently failing as protoc (required to generate the protobuf stubs) wasn't installed within the CI job