### PR TITLE
Add a v-version tag for golang module

### DIFF
--- a/.changeset/loud-goats-dream.md
+++ b/.changeset/loud-goats-dream.md
@@ -1,0 +1,6 @@
+---
+"github.com/livekit/protocol": minor
+"@livekit/protocol": minor
+---
+
+Align package version with manually tagged golang module

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,6 @@ jobs:
         uses: rickstaa/action-create-tag@v1
         id: tag_create
         with:
-          tag: "v${{steps.changesets.outputs.publishedPackages.version}}"
+          tag: "v${{steps.changesets.outputs.publishedPackages[0].version}}"
           tag_exists_error: false
           message: "github.com/livekit/protocol@${{steps.changesets.outputs.publishedPackages.version}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,3 +41,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create git tag for golang package
+        if: steps.changesets.outputs.published == 'true'
+        uses: rickstaa/action-create-tag@v1
+        id: tag_create
+        with:
+          tag: "v${{steps.changesets.outputs.publishedPackages.version}}"
+          tag_exists_error: false
+          message: "github.com/livekit/protocol@${{steps.changesets.outputs.publishedPackages.version}}"


### PR DESCRIPTION
When running the publish+release action, the changesets publish command will automatically create a github tag for each package within the monorepo. The format for this is `packageName@x.x.x`. Which arguably makes a lot of sense for monorepos, but because we also want to use the git tags for golang module package releases we need a git tag with the format `vX.X.X`. 

This PR creates that additional `v` version tag manually whenever the changeset action has created another release tag.