### PR TITLE
Move CPU stats to a separate hwstats package

### DIFF
--- a/.changeset/polite-hounds-tickle.md
+++ b/.changeset/polite-hounds-tickle.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": minor
+---
+
+Moved CPU stats to a separate hwstats package, removing cgo dependency.

--- a/utils/hwstats/cpu.go
+++ b/utils/hwstats/cpu.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package hwstats
 
 import (
 	"time"

--- a/utils/hwstats/cpu_all.go
+++ b/utils/hwstats/cpu_all.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package hwstats
 
 import (
 	"runtime"

--- a/utils/hwstats/cpu_darwin.go
+++ b/utils/hwstats/cpu_darwin.go
@@ -12,30 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(linux || darwin)
+//go:build darwin
 
-package utils
+package hwstats
 
 import (
 	"runtime"
 
-	"github.com/livekit/protocol/logger"
 	"github.com/prometheus/procfs"
 )
 
-type nullStatCPUMonitor struct{}
-
-func (p *nullStatCPUMonitor) getCPUIdle() (float64, error) {
-	return float64(runtime.NumCPU()), nil
-}
-
-func (p *nullStatCPUMonitor) numCPU() float64 {
-	return float64(runtime.NumCPU())
-}
 func newPlatformCPUMonitor() (platformCPUMonitor, error) {
-	logger.Errorw("CPU monitoring unsupported on current platform. Server capacity management will be disabled", nil)
-
-	return &nullStatCPUMonitor{}, nil
+	return newOSStatCPUMonitor()
 }
 
 func getHostCPUCount(fs procfs.FS) (float64, error) {

--- a/utils/hwstats/cpu_linux.go
+++ b/utils/hwstats/cpu_linux.go
@@ -14,7 +14,7 @@
 
 //go:build linux
 
-package utils
+package hwstats
 
 import (
 	"errors"

--- a/utils/hwstats/cpu_null.go
+++ b/utils/hwstats/cpu_null.go
@@ -12,18 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build darwin
+//go:build !(linux || darwin)
 
-package utils
+package hwstats
 
 import (
 	"runtime"
 
 	"github.com/prometheus/procfs"
+
+	"github.com/livekit/protocol/logger"
 )
 
+type nullStatCPUMonitor struct{}
+
+func (p *nullStatCPUMonitor) getCPUIdle() (float64, error) {
+	return float64(runtime.NumCPU()), nil
+}
+
+func (p *nullStatCPUMonitor) numCPU() float64 {
+	return float64(runtime.NumCPU())
+}
 func newPlatformCPUMonitor() (platformCPUMonitor, error) {
-	return newOSStatCPUMonitor()
+	logger.Errorw("CPU monitoring unsupported on current platform. Server capacity management will be disabled", nil)
+
+	return &nullStatCPUMonitor{}, nil
 }
 
 func getHostCPUCount(fs procfs.FS) (float64, error) {


### PR DESCRIPTION
Move CPU stats to a separate `hwstats` package to avoid cgo dependency from `github.com/mackerelio/go-osstat`.

LiveKit code that uses `CPUStats` will need to update imports from `.../protocol/utils` to `.../protocol/utils/hwstats`.

Fixes #659.