### PR TITLE
Fix workflow formatted release message

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,6 @@ jobs:
         uses: rickstaa/action-create-tag@v1
         id: tag_create
         with:
-          tag: ${{ format('v{0}', steps.changesets.outputs.publishedPackages[0].version) }}
+          tag: ${{ format('v{0}', fromJson(steps.changesets.outputs.publishedPackages)[0].version) }}
           tag_exists_error: false
-          message: ${{ format('github.com/livekit/protocol@{0}', steps.changesets.outputs.publishedPackages[0].version) }}
+          message: ${{ format('github.com/livekit/protocol@{0}', fromJson(steps.changesets.outputs.publishedPackages)[0].version) }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,6 @@ jobs:
         uses: rickstaa/action-create-tag@v1
         id: tag_create
         with:
-          tag: ${{format('v{0}', steps.changesets.outputs.publishedPackages[0].version)}}
+          tag: ${{ format('v{0}', steps.changesets.outputs.publishedPackages[0].version) }}
           tag_exists_error: false
-          message: "github.com/livekit/protocol@${{steps.changesets.outputs.publishedPackages.version}}"
+          message: ${{ format('github.com/livekit/protocol@{0}', steps.changesets.outputs.publishedPackages[0].version) }}


### PR DESCRIPTION
the published package output was a plain string, converting it to JSON first fixes the problem where an empty `v` tag got created. Tested and verified this on a separate repo.