### PR TITLE
fix: rate limit update and slack unit

### DIFF
--- a/utils/rate.go
+++ b/utils/rate.go
@@ -43,18 +43,18 @@ type leakyBucketConfig struct {
 	maxSlack   time.Duration
 }
 
-func NewLeakyBucket(rateLimit int, slack time.Duration, clock Clock) *LeakyBucket {
+func NewLeakyBucket(rateLimit int, slack int, clock Clock) *LeakyBucket {
 	var lb LeakyBucket
 	lb.clock = clock
 	lb.Update(rateLimit, slack)
 	return &lb
 }
 
-// Update sets the underlying rate limit.
+// Update sets the underlying rate limit and slack.
 // The setting may not be applied immediately.
 //
 // Update is THREAD SAFE and NON-BLOCKING.
-func (lb *LeakyBucket) Update(rateLimit int, slack time.Duration) {
+func (lb *LeakyBucket) Update(rateLimit int, slack int) {
 	perRequest := time.Second / time.Duration(rateLimit)
 	maxSlack := -1 * time.Duration(slack) * perRequest
 	cfg := leakyBucketConfig{

--- a/utils/rate.go
+++ b/utils/rate.go
@@ -43,6 +43,13 @@ type leakyBucketConfig struct {
 	maxSlack   time.Duration
 }
 
+// NewLeakyBucket initiates LeakyBucket with rateLimit, slack, and clock.
+//
+// rateLimit is defined as the number of request per second.
+//
+// slack is defined as the number of allowed requests before limiting.
+// e.g. when slack=5, LeakyBucket will allow 5 requests to pass through Take
+// without a sleep as long as these requests are under perRequest duration.
 func NewLeakyBucket(rateLimit int, slack int, clock Clock) *LeakyBucket {
 	var lb LeakyBucket
 	lb.clock = clock


### PR DESCRIPTION
* the slack unit should be int instead of duration
* on an update, the max slack needs to be updated as well