### PR TITLE
lazily initialize pion loggers

### DIFF
--- a/logger/pionlogger/logger.go
+++ b/logger/pionlogger/logger.go
@@ -48,20 +48,39 @@ var (
 	}
 )
 
-// LoggerFactory implements webrtc.LoggerFactory interface
-type LoggerFactory struct {
+func NewLoggerFactory(l logger.Logger) logging.LoggerFactory {
+	if zl, ok := l.(logger.ZapLogger); ok {
+		return &zapLoggerFactory{zl}
+	}
+	return &loggerFactory{l}
+}
+
+// zapLoggerFactory implements logging.LoggerFactory interface for zap loggers
+type zapLoggerFactory struct {
+	logger logger.ZapLogger
+}
+
+func (f *zapLoggerFactory) NewLogger(scope string) logging.LeveledLogger {
+	return &zapLogAdapter{
+		logger:          f.logger,
+		level:           f.logger.ComponentLeveler().ComponentLevel(formatComponent(scope)),
+		scope:           scope,
+		ignoredPrefixes: pionIgnoredPrefixes[scope],
+	}
+}
+
+// loggerFactory implements logging.LoggerFactory interface for generic loggers
+type loggerFactory struct {
 	logger logger.Logger
 }
 
-func NewLoggerFactory(logger logger.Logger) *LoggerFactory {
-	return &LoggerFactory{
-		logger: logger,
+func (f *loggerFactory) NewLogger(scope string) logging.LeveledLogger {
+	return &logAdapter{
+		logger:          f.logger.WithComponent(formatComponent(scope)).WithCallDepth(1),
+		ignoredPrefixes: pionIgnoredPrefixes[scope],
 	}
 }
 
-func (f *LoggerFactory) NewLogger(scope string) logging.LeveledLogger {
-	return &logAdapter{
-		logger:          f.logger.WithComponent("pion." + scope).WithCallDepth(1),
-		ignoredPrefixes: pionIgnoredPrefixes[scope],
-	}
+func formatComponent(scope string) string {
+	return "pion." + scope
 }

--- a/logger/pionlogger/zaplogadapter.go
+++ b/logger/pionlogger/zaplogadapter.go
@@ -1,0 +1,149 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pionlogger
+
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/livekit/protocol/logger"
+)
+
+const (
+	zapLogAdapterStateCreated = iota
+	zapLogAdapterStateBuilding
+	zapLogAdapterStateReady
+)
+
+// implements webrtc.LeveledLogger
+type zapLogAdapter struct {
+	state           atomic.Uint32
+	logger          logger.ZapLogger
+	level           zapcore.LevelEnabler
+	scope           string
+	ignoredPrefixes []string
+}
+
+func (l *zapLogAdapter) init() {
+	for l.state.Load() != zapLogAdapterStateReady {
+		if l.state.CompareAndSwap(zapLogAdapterStateCreated, zapLogAdapterStateBuilding) {
+			l.logger = l.logger.WithComponent(formatComponent(l.scope)).WithCallDepth(1).(logger.ZapLogger)
+			l.state.Store(zapLogAdapterStateReady)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Trace(msg string) {
+	if l.level.Enabled(zap.DebugLevel) {
+		l.init()
+		l.logger.Debugw(msg)
+	}
+}
+
+func (l *zapLogAdapter) Tracef(format string, args ...interface{}) {
+	if l.level.Enabled(zap.DebugLevel) {
+		l.init()
+		l.logger.Debugw(fmt.Sprintf(format, args...))
+	}
+}
+
+func (l *zapLogAdapter) Debug(msg string) {
+	if l.level.Enabled(zap.DebugLevel) {
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Debugw(msg)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Debugf(format string, args ...interface{}) {
+	if l.level.Enabled(zap.DebugLevel) {
+		msg := fmt.Sprintf(format, args...)
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Debugw(msg)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Info(msg string) {
+	if l.level.Enabled(zap.InfoLevel) {
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Infow(msg)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Infof(format string, args ...interface{}) {
+	if l.level.Enabled(zap.InfoLevel) {
+		msg := fmt.Sprintf(format, args...)
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Infow(msg)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Warn(msg string) {
+	if l.level.Enabled(zap.WarnLevel) {
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Warnw(msg, nil)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Warnf(format string, args ...interface{}) {
+	if l.level.Enabled(zap.WarnLevel) {
+		msg := fmt.Sprintf(format, args...)
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Warnw(msg, nil)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Error(msg string) {
+	if l.level.Enabled(zap.ErrorLevel) {
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Errorw(msg, nil)
+		}
+	}
+}
+
+func (l *zapLogAdapter) Errorf(format string, args ...interface{}) {
+	if l.level.Enabled(zap.ErrorLevel) {
+		msg := fmt.Sprintf(format, args...)
+		if !l.shouldIgnore(msg) {
+			l.init()
+			l.logger.Errorw(msg, nil)
+		}
+	}
+}
+
+func (l *zapLogAdapter) shouldIgnore(msg string) bool {
+	for _, prefix := range l.ignoredPrefixes {
+		if strings.HasPrefix(msg, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/logger/zaputil/orlevelenabler.go
+++ b/logger/zaputil/orlevelenabler.go
@@ -1,0 +1,23 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zaputil
+
+import "go.uber.org/zap/zapcore"
+
+type OrLevelEnabler [2]zapcore.LevelEnabler
+
+func (e OrLevelEnabler) Enabled(lvl zapcore.Level) bool {
+	return e[0].Enabled(lvl) || e[1].Enabled(lvl)
+}

--- a/utils/hedge.go
+++ b/utils/hedge.go
@@ -1,3 +1,17 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/utils/hedge_test.go
+++ b/utils/hedge_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (


### PR DESCRIPTION
pion loggers are 9% of our heap objects in some regions and only produce a small number of error logs (2.6% of logs). i suspect most of them are never used. if this is true we can save ~7% of heap objects by deferring the bulk of initialization until we need to log something.