### PR TITLE
Convert changesets action output to JSON before accessing it

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,6 @@ jobs:
         uses: rickstaa/action-create-tag@v1
         id: tag_create
         with:
-          tag: ${{format('v{0}', steps.changesets.outputs.publishedPackages[0].version)}}
+          tag: ${{format('v{0}', fromJson(steps.changesets.outputs.publishedPackages)[0].version)}}
           tag_exists_error: false
-          message: "github.com/livekit/protocol@${{steps.changesets.outputs.publishedPackages.version}}"
+          message: "github.com/livekit/protocol@${{fromJson(steps.changesets.outputs.publishedPackages)[0].version}}"


### PR DESCRIPTION
the output of the changesets step is a plain string in JSON notation, that first needs to be parsed first.