### PR TITLE
Simplify number matching rules. Make '+' optional.

### DIFF
--- a/.changeset/clean-comics-cheat.md
+++ b/.changeset/clean-comics-cheat.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": minor
+---
+
+Simplify number matching rules for SIP.


### PR DESCRIPTION
Quite a few support questions from customers regarding SIP are made because of a tiny mistake in the number format in their Trunks. Twilio requires leading `+`, while Telnyx omits it by default.

This change makes `+` always optional for inbound calls. We will still accept the call if the Trunk has `+` set, but `INVITE` omits it (and vise versa).

In addition, make effort to fix outbound calls (`CreateSIPParticipant` requests) too by checking the base domain in SIP URI. It's not perfect and won't work if provider changes the domain. But it will help avoid most common problems.