### PR TITLE
Use glob for generating JS proto definitions

### DIFF
--- a/.changeset/chilled-nails-battle.md
+++ b/.changeset/chilled-nails-battle.md
@@ -1,0 +1,5 @@
+---
+"@livekit/protocol": patch
+---
+
+Use glob for generating JS proto definitions

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "generate:version": "genversion --esm --semi src/gen/version.js",
-    "generate:proto": "protoc --es_out src/gen --es_opt target=js+dts -I=../../protobufs ../../protobufs/livekit_room.proto ../../protobufs/livekit_rtc.proto ../../protobufs/livekit_models.proto ../../protobufs/livekit_agent.proto ../../protobufs/livekit_webhook.proto ../../protobufs/livekit_egress.proto ../../protobufs/livekit_ingress.proto ../../protobufs/livekit_sip.proto",
+    "generate:proto": "protoc --es_out src/gen --es_opt target=js+dts -I=../../protobufs ../../protobufs/livekit_*.proto",
     "build": "pnpm generate:version && pnpm generate:proto"
   },
   "keywords": [],


### PR DESCRIPTION
Previously single files were referenced for generating proto files. 

In https://github.com/livekit/protocol/pull/764 a new file `livekit_agent_dispatch.proto` was added, but missed in the JS package generation. Due to `livekit_room.proto` importing `livekit_agent_dispatch.proto` this lead to the latest JS release throwing a runtime error about the missing dispatch file 