### PR TITLE
add unlikely logger

### DIFF
--- a/utils/must/must.go
+++ b/utils/must/must.go
@@ -27,3 +27,7 @@ func Do(err error) {
 		panic(err)
 	}
 }
+
+func DoFunc(f func() error) func() {
+	return func() { Do(f()) }
+}


### PR DESCRIPTION
this is a lightweight version of `WithValues` that doesn't pessimistically marshal all of the values. this is intended for cases where we don't expect to call any of the log functions but it's inconvenient to repeat all of the arguments we want to log