### PR TITLE
Fix test deadlock on failure.

### DIFF
--- a/utils/rate_test.go
+++ b/utils/rate_test.go
@@ -252,8 +252,8 @@ func (r *runnerImpl) takeOnceAfter(d time.Duration, rl Limiter) {
 func (r *runnerImpl) assertCountAt(d time.Duration, count int) {
 	r.wg.Add(1)
 	r.afterFunc(d, func() {
+		defer r.wg.Done()
 		require.Equal(r.t, int32(count), r.count.Load(), "count not as expected")
-		r.wg.Done()
 	})
 }
 
@@ -261,9 +261,9 @@ func (r *runnerImpl) assertCountAt(d time.Duration, count int) {
 func (r *runnerImpl) assertCountAtWithNoise(d time.Duration, count int, noise int) {
 	r.wg.Add(1)
 	r.afterFunc(d, func() {
+		defer r.wg.Done()
 		require.InDelta(r.t, count, int(r.count.Load()), float64(noise),
 			"expected count to be within noise tolerance")
-		r.wg.Done()
 	})
 }
 


### PR DESCRIPTION
Functions in `require` package call `t.Fail` which is roughly equivalent to `panic` (both walk up the function stack).

Thus, calling `wg.Done()` after `require` becomes unreachable on test failure, deadlocking the goroutine that runs `wg.Wait()` (usually the main test goroutine). 