### PR TITLE
add zap object marshaler slice helper

### DIFF
--- a/logger/zaputil/slice.go
+++ b/logger/zaputil/slice.go
@@ -1,0 +1,16 @@
+package zaputil
+
+import "go.uber.org/zap/zapcore"
+
+func ObjectSlice[T zapcore.ObjectMarshaler](s []T) zapcore.ArrayMarshaler {
+	return objectSlice[T](s)
+}
+
+type objectSlice[T zapcore.ObjectMarshaler] []T
+
+func (a objectSlice[T]) MarshalLogArray(e zapcore.ArrayEncoder) error {
+	for _, o := range a {
+		e.AppendObject(o)
+	}
+	return nil
+}


### PR DESCRIPTION
```go
type loggableStruct struct{}

func (s *loggableStruct) MarshalLogObject(e zapcore.ObjectEncoder) error {
	e.AddString("te", "st")
	return nil
}

logger.Debugw("test", "tests", logger.ObjectSlice([]*loggableStruct{{}, {}, {}}))
```