### PR TITLE
Init AgentService and add method ListAgentWorker

### DIFF
--- a/.changeset/add-method-list-agent-worker.md
+++ b/.changeset/add-method-list-agent-worker.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+Init AgentService and add method ListAgentWorker

--- a/protobufs/livekit_agent.proto
+++ b/protobufs/livekit_agent.proto
@@ -21,6 +21,26 @@ option ruby_package = "LiveKit::Proto";
 
 import "livekit_models.proto";
 
+service AgentService {
+  rpc ListAgentWorker(ListAgentWorkerRequest) returns (ListAgentWorkerResponse);
+}
+
+message ListAgentWorkerRequest {
+  string agent_name = 1; // (optional, filter by agent name)
+  JobType job_type = 2; // (optional, filter by job type)
+}
+
+message ListAgentWorkerResponse {
+  repeated AgentWorker agent_workers = 1;
+}
+
+message AgentWorker {
+  string id = 1;
+  string agent_name = 2;
+  JobType job_type = 3;
+  float load = 4;
+}
+
 message Job {
   string id = 1;
   string dispatch_id = 9;

--- a/protobufs/rpc/agent.proto
+++ b/protobufs/rpc/agent.proto
@@ -26,6 +26,9 @@ service AgentInternal {
   rpc CheckEnabled(CheckEnabledRequest) returns (CheckEnabledResponse) {
     option (psrpc.options).multi = true;
   };
+  rpc ListWorker(livekit.ListAgentWorkerRequest) returns (livekit.ListAgentWorkerResponse) {
+    option (psrpc.options).multi = true;
+  };
   rpc JobRequest(livekit.Job) returns (JobRequestResponse) {
     option (psrpc.options) = {
       affinity_func: true


### PR DESCRIPTION
I add method ListAgentWorker to let the admin can manipulate number of current agent workers, in order to control the scalability of agents.