### PR TITLE
Add helper to get SIP call status from an error.

### DIFF
--- a/.changeset/sip-status-helper.md
+++ b/.changeset/sip-status-helper.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": minor
+---
+
+Add helper to get SIP call status from an error.

--- a/livekit/sip.go
+++ b/livekit/sip.go
@@ -20,6 +20,20 @@ var (
 	_ error            = (*SIPStatus)(nil)
 )
 
+// SIPStatusFrom unwraps an error and returns associated SIP call status, if any.
+func SIPStatusFrom(err error) *SIPStatus {
+	st, ok := status.FromError(err)
+	if !ok {
+		return nil
+	}
+	for _, d := range st.Details() {
+		if e, ok := d.(*SIPStatus); ok {
+			return e
+		}
+	}
+	return nil
+}
+
 func (p SIPStatusCode) ShortName() string {
 	return strings.TrimPrefix(p.String(), "SIP_STATUS_")
 }


### PR DESCRIPTION
Add helper to get SIP call status from an error. The implementation is the same as used in Go SDK.