### PR TITLE
Fix paths and simplify.

### DIFF
--- a/utils/hwstats/memory_linux.go
+++ b/utils/hwstats/memory_linux.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	memStatsPathV1 = "/sys/fs/memory/memory.usage_in_bytes"
+	memStatsPathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
 	memStatsPathV2 = "/sys/fs/memory/memory.current"
 
 	memUsagePathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
@@ -62,6 +62,7 @@ func newPlatformMemoryGetter() (platformMemoryGetter, error) {
 			return nil, err
 		}
 		if e {
+			logger.Infow("using getter", "key", k) // REMOVE
 			cg = v(osStat)
 			break
 		}
@@ -130,12 +131,13 @@ func newMemInfoGetterV2(osStat *osStatMemoryGetter) memInfoGetter {
 }
 
 func (cg *memInfoGetterV2) getMemory() (uint64, uint64, error) {
-	usage, err := readValueFromFile(memCurrentPathV2)
-	if err != nil {
-		return 0, 0, err
+	usage, err1 := readValueFromFile(memCurrentPathV2)
+	if err1 != nil {
+		return 0, 0, err1
 	}
 
 	total, err := readValueFromFile(memMaxPathV2)
+	logger.Infow("memory v2 usage", "usage", usage, "err1", err1, "total", total, "err", err) // REMOVE
 	if err != nil {
 		// when memory limit not set, it has the string "max"
 		usage, total, err = cg.osStat.getMemory()
@@ -155,6 +157,7 @@ func readValueFromFile(file string) (uint64, error) {
 		return 0, err
 	}
 
+	logger.Infow("read file", "file", file, "value", string(b), "truncated", string(b[:len(b)-1])) // REMOVE
 	// Skip the trailing EOL
 	return strconv.ParseUint(string(b[:len(b)-1]), 10, 64)
 }

--- a/utils/hwstats/memory_linux.go
+++ b/utils/hwstats/memory_linux.go
@@ -59,7 +59,6 @@ func newPlatformMemoryGetter() (platformMemoryGetter, error) {
 			return nil, err
 		}
 		if e {
-			logger.Infow("DEBUG using getter", "key", k) // REMOVE
 			cg = v(osStat)
 			break
 		}
@@ -105,7 +104,6 @@ func (cg *memInfoGetterV1) getMemory() (uint64, uint64, error) {
 	// fallback if limit from cgroup is more than physical available memory
 	// when limit is not set explicitly, it could be very high
 	usage1, total1, err := cg.osStat.getMemory()
-	logger.Infow("DEBUG memory v1 usage", "usage", usage, "total", total, "err", err, "usage1", usage1, "total1", total1) // REMOVE
 	if err != nil {
 		return 0, 0, err
 	}
@@ -135,7 +133,6 @@ func (cg *memInfoGetterV2) getMemory() (uint64, uint64, error) {
 	}
 
 	total, err := readValueFromFile(memMaxPathV2)
-	logger.Infow("DEBUG memory v2 usage", "usage", usage, "err1", err1, "total", total, "err", err) // REMOVE
 	if err != nil {
 		// when memory limit not set, it has the string "max"
 		usage, total, err = cg.osStat.getMemory()
@@ -155,7 +152,6 @@ func readValueFromFile(file string) (uint64, error) {
 		return 0, err
 	}
 
-	logger.Infow("DEBUG read file", "file", file, "value", string(b), "truncated", string(b[:len(b)-1])) // REMOVE
 	// Skip the trailing EOL
 	return strconv.ParseUint(string(b[:len(b)-1]), 10, 64)
 }

--- a/utils/hwstats/memory_linux.go
+++ b/utils/hwstats/memory_linux.go
@@ -24,9 +24,6 @@ import (
 )
 
 const (
-	memStatsPathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
-	memStatsPathV2 = "/sys/fs/memory/memory.current"
-
 	memUsagePathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
 	memLimitPathV1 = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 
@@ -54,8 +51,8 @@ func newPlatformMemoryGetter() (platformMemoryGetter, error) {
 	// probe for the cgroup version
 	var cg memInfoGetter
 	for k, v := range map[string]func(osStat *osStatMemoryGetter) memInfoGetter{
-		memStatsPathV1: newMemInfoGetterV1,
-		memStatsPathV2: newMemInfoGetterV2,
+		memUsagePathV1:   newMemInfoGetterV1,
+		memCurrentPathV2: newMemInfoGetterV2,
 	} {
 		e, err := fileExists(k)
 		if err != nil {

--- a/utils/hwstats/memory_linux.go
+++ b/utils/hwstats/memory_linux.go
@@ -62,7 +62,7 @@ func newPlatformMemoryGetter() (platformMemoryGetter, error) {
 			return nil, err
 		}
 		if e {
-			logger.Infow("using getter", "key", k) // REMOVE
+			logger.Infow("DEBUG using getter", "key", k) // REMOVE
 			cg = v(osStat)
 			break
 		}
@@ -108,6 +108,7 @@ func (cg *memInfoGetterV1) getMemory() (uint64, uint64, error) {
 	// fallback if limit from cgroup is more than physical available memory
 	// when limit is not set explicitly, it could be very high
 	usage1, total1, err := cg.osStat.getMemory()
+	logger.Infow("DEBUG memory v1 usage", "usage", usage, "total", total, "err", err, "usage1", usage1, "total1", total1) // REMOVE
 	if err != nil {
 		return 0, 0, err
 	}
@@ -137,7 +138,7 @@ func (cg *memInfoGetterV2) getMemory() (uint64, uint64, error) {
 	}
 
 	total, err := readValueFromFile(memMaxPathV2)
-	logger.Infow("memory v2 usage", "usage", usage, "err1", err1, "total", total, "err", err) // REMOVE
+	logger.Infow("DEBUG memory v2 usage", "usage", usage, "err1", err1, "total", total, "err", err) // REMOVE
 	if err != nil {
 		// when memory limit not set, it has the string "max"
 		usage, total, err = cg.osStat.getMemory()
@@ -157,7 +158,7 @@ func readValueFromFile(file string) (uint64, error) {
 		return 0, err
 	}
 
-	logger.Infow("read file", "file", file, "value", string(b), "truncated", string(b[:len(b)-1])) // REMOVE
+	logger.Infow("DEBUG read file", "file", file, "value", string(b), "truncated", string(b[:len(b)-1])) // REMOVE
 	// Skip the trailing EOL
 	return strconv.ParseUint(string(b[:len(b)-1]), 10, 64)
 }


### PR DESCRIPTION
Had the v1 check path wrong, so it ended up using v1 getter on a node with cgroup v2.