### PR TITLE
Use custom histogram buckets.

### DIFF
--- a/webhook/stats.go
+++ b/webhook/stats.go
@@ -45,7 +45,7 @@ func initWebhookStats(constLabels prometheus.Labels) {
 		Subsystem:   "webhook",
 		Name:        "queue_length",
 		ConstLabels: constLabels,
-		Buckets:     prometheus.ExponentialBucketsRange(1, 100, 4),
+		Buckets:     []float64{1, 2, 3, 4, 5, 10, 20, 40, 80},
 	})
 }
 


### PR DESCRIPTION
Setting 4 buckets with exponential in range 1, 100 meant the boundaries were at 1, 4.64, 21.53, 100. Because of that, the p99 looked misleadingly large.