### PR TITLE
SDP utilities to get simulcast RIDs and media stream track.

### DIFF
--- a/sdp/sdp_test.go
+++ b/sdp/sdp_test.go
@@ -51,7 +51,8 @@ func TestSDPUtilFunctions(t *testing.T) {
 	require.False(t, found)
 	require.Empty(t, streamID)
 
-	require.False(t, IsMediaDescriptionSimulcast(parsed.MediaDescriptions[1]))
+	_, ok := GetSimulcastRids(parsed.MediaDescriptions[1])
+	require.False(t, ok)
 
 	codecs, err := CodecsFromMediaDescription(parsed.MediaDescriptions[0])
 	require.NoError(t, err)


### PR DESCRIPTION
Some slight variations from this PR (https://github.com/livekit/protocol/pull/1018)