### PR TITLE
Adding the agent gateway prefix. 

### DIFF
--- a/utils/guid/id.go
+++ b/utils/guid/id.go
@@ -59,6 +59,7 @@ const (
 	CloudAgentVersionPrefix = "CAV_"
 	CloudAgentSecretPrefix  = "CAS_"
 	CloudAgentWorkerPrefix  = "CAW_"
+	AgentGatewayPrefix      = "GW_"
 )
 
 var guidGeneratorPool = sync.Pool{


### PR DESCRIPTION
A node ID is required when creating a quota client, adding the prefix here.