### PR TITLE
chore: rename ListUpdate field `del` -> `remove`

### DIFF
--- a/.changeset/green-groups-unite.md
+++ b/.changeset/green-groups-unite.md
@@ -1,0 +1,6 @@
+---
+"github.com/livekit/protocol": minor
+"@livekit/protocol": minor
+---
+
+rename ListUpdate "del" field to "rename"

--- a/livekit/livekit_models.pb.go
+++ b/livekit/livekit_models.pb.go
@@ -1357,10 +1357,10 @@ func (x *TokenPagination) GetToken() string {
 // ListUpdate is used for updated APIs where 'repeated string' field is modified.
 type ListUpdate struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Set           []string               `protobuf:"bytes,1,rep,name=set,proto3" json:"set,omitempty"`      // set the field to a new list
-	Add           []string               `protobuf:"bytes,2,rep,name=add,proto3" json:"add,omitempty"`      // append items to a list, avoiding duplicates
-	Del           []string               `protobuf:"bytes,3,rep,name=del,proto3" json:"del,omitempty"`      // delete items from a list
-	Clear         bool                   `protobuf:"varint,4,opt,name=clear,proto3" json:"clear,omitempty"` // sets the list to an empty list
+	Set           []string               `protobuf:"bytes,1,rep,name=set,proto3" json:"set,omitempty"`       // set the field to a new list
+	Add           []string               `protobuf:"bytes,2,rep,name=add,proto3" json:"add,omitempty"`       // append items to a list, avoiding duplicates
+	Remove        []string               `protobuf:"bytes,3,rep,name=remove,proto3" json:"remove,omitempty"` // delete items from a list
+	Clear         bool                   `protobuf:"varint,4,opt,name=clear,proto3" json:"clear,omitempty"`  // sets the list to an empty list
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1409,9 +1409,9 @@ func (x *ListUpdate) GetAdd() []string {
 	return nil
 }
 
-func (x *ListUpdate) GetDel() []string {
+func (x *ListUpdate) GetRemove() []string {
 	if x != nil {
-		return x.Del
+		return x.Remove
 	}
 	return nil
 }
@@ -5658,12 +5658,12 @@ const file_livekit_models_proto_rawDesc = "" +
 	"\bafter_id\x18\x01 \x01(\tR\aafterId\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\x05R\x05limit\"'\n" +
 	"\x0fTokenPagination\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\tR\x05token\"X\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\"^\n" +
 	"\n" +
 	"ListUpdate\x12\x10\n" +
 	"\x03set\x18\x01 \x03(\tR\x03set\x12\x10\n" +
-	"\x03add\x18\x02 \x03(\tR\x03add\x12\x10\n" +
-	"\x03del\x18\x03 \x03(\tR\x03del\x12\x14\n" +
+	"\x03add\x18\x02 \x03(\tR\x03add\x12\x16\n" +
+	"\x06remove\x18\x03 \x03(\tR\x06remove\x12\x14\n" +
 	"\x05clear\x18\x04 \x01(\bR\x05clear\"\x9e\x04\n" +
 	"\x04Room\x12\x10\n" +
 	"\x03sid\x18\x01 \x01(\tR\x03sid\x12\x12\n" +

--- a/livekit/types.go
+++ b/livekit/types.go
@@ -227,14 +227,14 @@ func (p *ListUpdate) Validate() error {
 	if p == nil {
 		return nil
 	}
-	change := len(p.Set)+len(p.Add)+len(p.Del) > 0
+	change := len(p.Set)+len(p.Add)+len(p.Remove) > 0
 	if !p.Clear && !change {
 		return fmt.Errorf("unsupported list update operation")
 	}
 	if p.Clear && change {
 		return fmt.Errorf("cannot clear and change the list at the same time")
 	}
-	if len(p.Set) > 0 && len(p.Add)+len(p.Del) > 0 {
+	if len(p.Set) > 0 && len(p.Add)+len(p.Remove) > 0 {
 		return fmt.Errorf("cannot set and change the list at the same time")
 	}
 	for _, v := range p.Set {
@@ -247,7 +247,7 @@ func (p *ListUpdate) Validate() error {
 			return fmt.Errorf("empty element in the list")
 		}
 	}
-	for _, v := range p.Del {
+	for _, v := range p.Remove {
 		if v == "" {
 			return fmt.Errorf("empty element in the list")
 		}
@@ -292,7 +292,7 @@ func applyListUpdate[T ~string](dst *[]T, u *ListUpdate) {
 		return
 	}
 	arr := slices.Clone(*dst)
-	for _, v := range u.Del {
+	for _, v := range u.Remove {
 		if i := slices.Index(arr, T(v)); i >= 0 {
 			arr = slices.Delete(arr, i, i+1)
 		}

--- a/livekit/types_test.go
+++ b/livekit/types_test.go
@@ -269,8 +269,8 @@ func TestListUpdate(t *testing.T) {
 			Err:    true,
 		},
 		{
-			Name:   "set and del",
-			Update: &ListUpdate{Set: []string{"a"}, Del: []string{"b"}},
+			Name:   "set and remove",
+			Update: &ListUpdate{Set: []string{"a"}, Remove: []string{"b"}},
 			Err:    true,
 		},
 		{
@@ -292,15 +292,15 @@ func TestListUpdate(t *testing.T) {
 			Exp:    []string{"a", "b", "c"},
 		},
 		{
-			Name:   "del",
+			Name:   "remove",
 			Arr:    []string{"a", "b"},
-			Update: &ListUpdate{Del: []string{"b", "c"}},
+			Update: &ListUpdate{Remove: []string{"b", "c"}},
 			Exp:    []string{"a"},
 		},
 		{
-			Name:   "add and del",
+			Name:   "add and remove",
 			Arr:    []string{"a", "b", "c"},
-			Update: &ListUpdate{Add: []string{"b", "d"}, Del: []string{"c", "e"}},
+			Update: &ListUpdate{Add: []string{"b", "d"}, Remove: []string{"c", "e"}},
 			Exp:    []string{"a", "b", "d"},
 		},
 	}

--- a/protobufs/livekit_models.proto
+++ b/protobufs/livekit_models.proto
@@ -36,7 +36,7 @@ message TokenPagination {
 message ListUpdate {
   repeated string set = 1; // set the field to a new list
   repeated string add = 2; // append items to a list, avoiding duplicates
-  repeated string del = 3; // delete items from a list
+  repeated string remove = 3; // delete items from a list
   bool clear = 4; // sets the list to an empty list
 }
 


### PR DESCRIPTION
In `ListUpdate` proto message, rename `del` field to `remove`. `del` is a reserved keyword in Python, and this field is omitted when generating code. We've verified that nobody has used this field in production yet.