### PR TITLE
Address typo in new livekit_token_source js client code

### DIFF
--- a/packages/javascript/src/index.d.ts
+++ b/packages/javascript/src/index.d.ts
@@ -8,6 +8,6 @@ export * from "./gen/livekit_models_pb.js";
 export * from "./gen/livekit_room_pb.js";
 export * from "./gen/livekit_rtc_pb.js";
 export * from "./gen/livekit_sip_pb.js";
-export * from "./gen/livekit_token_source.js";
+export * from "./gen/livekit_token_source_pb.js";
 export * from "./gen/livekit_webhook_pb.js";
 export * from "./gen/version.js";

--- a/packages/javascript/src/index.js
+++ b/packages/javascript/src/index.js
@@ -9,6 +9,6 @@ export * from "./gen/livekit_models_pb.js";
 export * from "./gen/livekit_room_pb.js";
 export * from "./gen/livekit_rtc_pb.js";
 export * from "./gen/livekit_sip_pb.js";
-export * from "./gen/livekit_token_source.js";
+export * from "./gen/livekit_token_source_pb.js";
 export * from "./gen/livekit_webhook_pb.js";
 export * from "./gen/version.js";


### PR DESCRIPTION
After merging https://github.com/livekit/protocol/pull/1224, the ci build broke.

It should have been `livekit_token_source_pb`, I got the file name wrong 🤦 

(Note: not including a new changeset on purpose because I want to re-publish under the old version from the commit that failed)