### PR TITLE
Webhook filter omitempty

### DIFF
--- a/webhook/notifier.go
+++ b/webhook/notifier.go
@@ -188,8 +188,8 @@ type HTTPClientParams struct {
 }
 
 type FilterParams struct {
-	IncludeEvents []string
-	ExcludeEvents []string
+	IncludeEvents []string `yaml:"include_events,omitempty"`
+	ExcludeEvents []string `yaml:"exclude_events,omitempty"`
 }
 
 // ---------------------------------


### PR DESCRIPTION
when updating the cloud repo to use webhook filter, a test failed because it is requiring `omitempty`

```
config_test.go:331: 
    Error Trace:	/home/runner/work/cloud/cloud/pkg/config/config_test.go:331
    Error:      	Received unexpected error:
          	        the following errors occurred:
          	            -  github.com/livekit/protocol/webhook/FilterParams.IncludeEvents missing omitempty tag
          	            -  github.com/livekit/protocol/webhook/FilterParams.ExcludeEvents missing omitempty tag
    Test:       	TestYAMLTag
```