### PR TITLE
Move rtpConverter from Go SDK for wider use.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/livekit/psrpc v0.7.0
 	github.com/mackerelio/go-osstat v0.2.5
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.11.1
+	github.com/nyaruka/phonenumbers v1.6.5
 	github.com/pion/logging v0.2.4
 	github.com/pion/sdp/v3 v3.0.14
 	github.com/pion/webrtc/v4 v4.1.2
@@ -63,7 +64,6 @@ require (
 	github.com/nats-io/nats.go v1.43.0 // indirect
 	github.com/nats-io/nkeys v0.4.11 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/nyaruka/phonenumbers v1.6.5 // indirect
 	github.com/pion/datachannel v1.5.10 // indirect
 	github.com/pion/dtls/v3 v3.0.6 // indirect
 	github.com/pion/ice/v4 v4.0.10 // indirect

--- a/utils/rtpconverter.go
+++ b/utils/rtpconverter.go
@@ -1,0 +1,50 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "time"
+
+type RTPConverter struct {
+	ts  uint64
+	rtp uint64
+}
+
+func NewRTPConverter(clockRate int64) *RTPConverter {
+	ts := time.Second.Nanoseconds()
+	for _, i := range []int64{10, 3, 2} {
+		for ts%i == 0 && clockRate%i == 0 {
+			ts /= i
+			clockRate /= i
+		}
+	}
+
+	return &RTPConverter{ts: uint64(ts), rtp: uint64(clockRate)}
+}
+
+func (r *RTPConverter) ToDuration(rtpTicks uint32) time.Duration {
+	return time.Duration(uint64(rtpTicks) * r.ts / r.rtp)
+}
+
+func (r *RTPConverter) ToDurationExt(rtpExtTicks uint64) time.Duration {
+	return time.Duration(uint64(rtpExtTicks) * r.ts / r.rtp)
+}
+
+func (r *RTPConverter) ToRTP(duration time.Duration) uint32 {
+	return uint32(duration.Nanoseconds() * int64(r.rtp) / int64(r.ts))
+}
+
+func (r *RTPConverter) ToRTPExt(duration time.Duration) uint64 {
+	return uint64(duration.Nanoseconds() * int64(r.rtp) / int64(r.ts))
+}

--- a/utils/rtpconverter_test.go
+++ b/utils/rtpconverter_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRTPConverter(t *testing.T) {
+	r := NewRTPConverter(90000)
+	require.Equal(t, time.Second, r.ToDuration(90000))
+	require.Equal(t, 500*time.Millisecond, r.ToDuration(45000))
+	require.Equal(t, time.Millisecond, r.ToDuration(90))
+
+	r = NewRTPConverter(48000)
+	require.Equal(t, time.Second, r.ToDurationExt(48000))
+	require.Equal(t, 48*time.Hour, r.ToDurationExt(24*60*60*2*48000))
+
+	r = NewRTPConverter(44100)
+	require.Equal(t, uint32(44100), r.ToRTP(time.Second))
+	require.Equal(t, uint32(44), r.ToRTP(time.Millisecond)) // 44.1 gets truncated to 44
+
+	r = NewRTPConverter(8000)
+	require.Equal(t, uint64(8000), r.ToRTPExt(time.Second))
+	require.Equal(t, uint64(24*60*60*10*8000), r.ToRTPExt(240*time.Hour))
+}


### PR DESCRIPTION
And add some simple tests.