### PR TITLE
generated: add eot reporter methods to gatewayobs

### DIFF
--- a/.changeset/perfect-pans-notice.md
+++ b/.changeset/perfect-pans-notice.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+generated: add eot reporter methods to gatewayobs

--- a/observability/gatewayobs/gen_reporter.go
+++ b/observability/gatewayobs/gen_reporter.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const Version_NI039G8 = true
+const Version_9V68R3G = true
 
 type KeyResolver interface {
 	Resolve(string)
@@ -85,6 +85,8 @@ type ModelTx interface {
 	ReportBargeInRequests(v uint64)
 	ReportBargeInRequestTypes(v ModelBargeInRequestTypes)
 	ReportVoiceCloneRequests(v uint64)
+	ReportEotRequests(v uint64)
+	ReportEotRequestTypes(v ModelEotRequestTypes)
 }
 
 type ModelReporter interface {

--- a/observability/gatewayobs/gen_reporter_noop.go
+++ b/observability/gatewayobs/gen_reporter_noop.go
@@ -137,3 +137,5 @@ func (r *noopModelReporter) ReportTtsChars(v uint32)                            
 func (r *noopModelReporter) ReportBargeInRequests(v uint64)                       {}
 func (r *noopModelReporter) ReportBargeInRequestTypes(v ModelBargeInRequestTypes) {}
 func (r *noopModelReporter) ReportVoiceCloneRequests(v uint64)                    {}
+func (r *noopModelReporter) ReportEotRequests(v uint64)                           {}
+func (r *noopModelReporter) ReportEotRequestTypes(v ModelEotRequestTypes)         {}

--- a/observability/gatewayobs/gen_source.go
+++ b/observability/gatewayobs/gen_source.go
@@ -9,6 +9,14 @@ const (
 	ModelBargeInRequestTypesSelfHosted ModelBargeInRequestTypes = "self_hosted"
 )
 
+type ModelEotRequestTypes string
+
+const (
+	ModelEotRequestTypesUndefined  ModelEotRequestTypes = ""
+	ModelEotRequestTypesCloud      ModelEotRequestTypes = "cloud"
+	ModelEotRequestTypesSelfHosted ModelEotRequestTypes = "self_hosted"
+)
+
 type Rollup string
 
 const (


### PR DESCRIPTION
Regenerated from cloud-observability schema/gateway.yaml changes that added `eot_requests` and `eot_request_types`. Adds `ModelEotRequestTypes` enum and `ReportEotRequests` / `ReportEotRequestTypes` methods on `ModelTx`.

Reference PR: https://github.com/livekit/protocol/pull/1415

Made-with: Cursor