### PR TITLE
Fix the egress results serialization format

### DIFF
--- a/.changeset/modern-fans-call.md
+++ b/.changeset/modern-fans-call.md
@@ -1,0 +1,5 @@
+---
+"@livekit/protocol": patch
+---
+
+Fix the egress results serialization format

--- a/observability/egressobs/egress.go
+++ b/observability/egressobs/egress.go
@@ -25,10 +25,10 @@ const (
 )
 
 type EgressResults struct {
-	FileResults    []*livekit.FileInfo
-	StreamResults  []*livekit.StreamInfo
-	SegmentResults []*livekit.SegmentsInfo
-	ImageResults   []*livekit.ImagesInfo
+	FileResults    []*livekit.FileInfo     `json:"file_results,omitempty"`
+	StreamResults  []*livekit.StreamInfo   `json:"stream_results,omitempty"`
+	SegmentResults []*livekit.SegmentsInfo `json:"segment_results,omitempty"`
+	ImageResults   []*livekit.ImagesInfo   `json:"image_results,omitempty"`
 }
 
 func GetSourceType(info *livekit.EgressInfo) SessionSourceType {
@@ -154,37 +154,36 @@ func GetRequest(info *livekit.EgressInfo) (string, error) {
 }
 
 func GetResult(info *livekit.EgressInfo) (string, error) {
+	var results *EgressResults
+
 	if file := info.GetFile(); file != nil {
-		b, err := protojson.Marshal(file)
-		if err != nil {
-			return "", errors.Wrap(err, "failed serializing File result")
+		results = &EgressResults{
+			FileResults: []*livekit.FileInfo{
+				file,
+			},
 		}
-		return string(b), nil
 	} else if stream := info.GetStream(); stream != nil {
-		b, err := protojson.Marshal(stream)
-		if err != nil {
-			return "", errors.Wrap(err, "failed serializing Stream result")
-		}
-		return string(b), nil
+		results = &EgressResults{}
+		results.StreamResults = append(results.StreamResults, stream.Info...)
 	} else if segments := info.GetSegments(); segments != nil {
-		b, err := protojson.Marshal(segments)
-		if err != nil {
-			return "", errors.Wrap(err, "failed serializing Segments result")
+		results = &EgressResults{
+			SegmentResults: []*livekit.SegmentsInfo{
+				segments,
+			},
 		}
-		return string(b), nil
 	} else {
-		results := &EgressResults{
+		results = &EgressResults{
 			FileResults:    info.FileResults,
 			StreamResults:  info.StreamResults,
 			SegmentResults: info.SegmentResults,
 			ImageResults:   info.ImageResults,
 		}
-		b, err := json.Marshal(results)
-		if err != nil {
-			return "", errors.Wrap(err, "failed serializing Multiple result")
-		}
-		return string(b), nil
 	}
+	b, err := json.Marshal(results)
+	if err != nil {
+		return "", errors.Wrap(err, "failed serializing results")
+	}
+	return string(b), nil
 }
 
 func GetAudioOnly(info *livekit.EgressInfo) bool {

--- a/observability/egressobs/egress_test.go
+++ b/observability/egressobs/egress_test.go
@@ -219,32 +219,38 @@ func TestGetRequest(t *testing.T) {
 
 func TestGetResult(t *testing.T) {
 	tests := []struct {
-		name string
-		info *livekit.EgressInfo
+		name     string
+		info     *livekit.EgressInfo
+		expected string
 	}{
 		{
 			name: "FileResult",
 			info: &livekit.EgressInfo{
 				Result: &livekit.EgressInfo_File{
-					File: &livekit.FileInfo{Filename: "test.mp4"},
+					File: &livekit.FileInfo{Filename: "test.mp4", Size: 1024},
 				},
 			},
+			expected: `{"file_results":[{"filename":"test.mp4", "size":1024}]}`,
 		},
 		{
 			name: "StreamResult",
 			info: &livekit.EgressInfo{
 				Result: &livekit.EgressInfo_Stream{
-					Stream: &livekit.StreamInfoList{},
+					Stream: &livekit.StreamInfoList{
+						Info: []*livekit.StreamInfo{{Url: "rtmp://example.com/live"}},
+					},
 				},
 			},
+			expected: `{"stream_results":[{"url":"rtmp://example.com/live"}]}`,
 		},
 		{
 			name: "SegmentResult",
 			info: &livekit.EgressInfo{
 				Result: &livekit.EgressInfo_Segments{
-					Segments: &livekit.SegmentsInfo{},
+					Segments: &livekit.SegmentsInfo{PlaylistName: "playlist.m3u8"},
 				},
 			},
+			expected: `{"segment_results":[{"playlist_name":"playlist.m3u8"}]}`,
 		},
 		{
 			name: "MultipleResults",
@@ -253,6 +259,7 @@ func TestGetResult(t *testing.T) {
 					{Filename: "test.mp4"},
 				},
 			},
+			expected: `{"file_results":[{"filename":"test.mp4"}]}`,
 		},
 	}
 
@@ -260,7 +267,7 @@ func TestGetResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := GetResult(tt.info)
 			require.NoError(t, err)
-			require.NotEmpty(t, result)
+			require.JSONEq(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Only serialize in the non deprecated format so no "ResultType" field is needed.