### PR TITLE
Fire next hedge attempt immediately when nothing is in flight

### DIFF
--- a/utils/hedge.go
+++ b/utils/hedge.go
@@ -35,6 +35,10 @@ type HedgeParams[T any] struct {
 // race retries if the function takes too long to return
 // |---------------- attempt 1 ----------------|
 // |    delay    |--------- attempt 2 ---------|
+//
+// If an attempt fails while no others are in flight, the next attempt
+// starts immediately rather than waiting out RetryDelay:
+// |-- attempt 1 --X|-- attempt 2 ----------|
 func HedgeCall[T any](ctx context.Context, params HedgeParams[T]) (v T, err error) {
 	ctx, cancel := context.WithTimeout(ctx, params.Timeout)
 	defer cancel()
@@ -73,6 +77,11 @@ func HedgeCall[T any](ctx context.Context, params HedgeParams[T]) (v T, err erro
 			if done++; done == params.MaxAttempts {
 				err = multierr.Append(err, ErrMaxAttemptsReached)
 				return
+			}
+			// No attempts are currently in flight — skip the remaining
+			// RetryDelay so the next attempt fires on the next iteration.
+			if attempt == done && attempt < params.MaxAttempts {
+				delay.Reset(0)
 			}
 		case <-ctx.Done():
 			err = multierr.Append(err, ctx.Err())

--- a/utils/hedge_test.go
+++ b/utils/hedge_test.go
@@ -89,6 +89,26 @@ func TestHedgeCall(t *testing.T) {
 		require.EqualValues(t, 2, attempts.Load())
 	})
 
+	t.Run("immediate retry when no requests in flight", func(t *testing.T) {
+		var attempts atomic.Uint32
+		start := time.Now()
+		res, err := HedgeCall(context.Background(), HedgeParams[uint32]{
+			Timeout:     1 * time.Second,
+			RetryDelay:  500 * time.Millisecond,
+			MaxAttempts: 2,
+			Func: func(context.Context) (uint32, error) {
+				n := attempts.Add(1)
+				if n == 1 {
+					return 0, errors.New("transient")
+				}
+				return n, nil
+			},
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 2, res)
+		require.Less(t, time.Since(start), 100*time.Millisecond)
+	})
+
 	t.Run("max failures", func(t *testing.T) {
 		var attempts atomic.Uint32
 		_, err := HedgeCall(context.Background(), HedgeParams[uint32]{


### PR DESCRIPTION
## Summary
- `HedgeCall`'s `RetryDelay` exists to stagger overlapping attempts; it shouldn't gate a retry when no attempts are currently in flight.
- When an attempt errors and `attempt == done` (no in-flight requests), reset the delay timer to `0` so the next attempt dispatches on the next loop iteration. When other attempts are still running, the existing staggering behavior is unchanged.
- Added a subtest that uses a 500ms `RetryDelay` and asserts the call returns in <100ms after a single transient failure.

## Test plan
- [x] `go test ./utils -run TestHedgeCall -race` passes (all 5 subtests, including the new `immediate retry when no requests in flight` case)