### PR TITLE
roomobs: report participant kind code and details

### DIFF
--- a/observability/roomobs/gen_reporter.go
+++ b/observability/roomobs/gen_reporter.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const Version_P3B2THO = true
+const Version_1HUONO8 = true
 
 type KeyResolver interface {
 	Resolve(string)
@@ -108,6 +108,8 @@ type participantSessionReporter interface {
 	ReportDurationSeconds(v uint16)
 	ReportDurationMinutes(v uint8)
 	ReportKind(v string)
+	ReportKindCode(v int32)
+	ReportKindDetailsCodes(v []int32)
 	ReportName(v string)
 	ReportFeatures(v uint16)
 	ReportCallID(v string)

--- a/observability/roomobs/gen_reporter_noop.go
+++ b/observability/roomobs/gen_reporter_noop.go
@@ -164,6 +164,8 @@ func (r *noopParticipantSessionReporter) ReportDuration(v uint16)               
 func (r *noopParticipantSessionReporter) ReportDurationSeconds(v uint16)                  {}
 func (r *noopParticipantSessionReporter) ReportDurationMinutes(v uint8)                   {}
 func (r *noopParticipantSessionReporter) ReportKind(v string)                             {}
+func (r *noopParticipantSessionReporter) ReportKindCode(v int32)                          {}
+func (r *noopParticipantSessionReporter) ReportKindDetailsCodes(v []int32)                {}
 func (r *noopParticipantSessionReporter) ReportName(v string)                             {}
 func (r *noopParticipantSessionReporter) ReportFeatures(v uint16)                         {}
 func (r *noopParticipantSessionReporter) ReportCallID(v string)                           {}
@@ -197,6 +199,8 @@ func (t *noopParticipantSessionTx) ReportDuration(v uint16)                {}
 func (t *noopParticipantSessionTx) ReportDurationSeconds(v uint16)         {}
 func (t *noopParticipantSessionTx) ReportDurationMinutes(v uint8)          {}
 func (t *noopParticipantSessionTx) ReportKind(v string)                    {}
+func (t *noopParticipantSessionTx) ReportKindCode(v int32)                 {}
+func (t *noopParticipantSessionTx) ReportKindDetailsCodes(v []int32)       {}
 func (t *noopParticipantSessionTx) ReportName(v string)                    {}
 func (t *noopParticipantSessionTx) ReportFeatures(v uint16)                {}
 func (t *noopParticipantSessionTx) ReportCallID(v string)                  {}

--- a/observability/roomobs/room.go
+++ b/observability/roomobs/room.go
@@ -159,3 +159,11 @@ func RoomFeatureFromParticipantKind(k livekit.ParticipantInfo_Kind) RoomFeature 
 		return 0
 	}
 }
+
+func ParticipantKindCode(k livekit.ParticipantInfo_Kind) int32 {
+	return int32(k)
+}
+
+func ParticipantKindDetailsCodes(d []livekit.ParticipantInfo_KindDetail) []int32 {
+	return *(*[]int32)(unsafe.Pointer(&d))
+}


### PR DESCRIPTION
## Summary
- Add `ReportKindCode` / `ReportKindDetailsCodes` on the participantSession reporter so callers can record the numeric `ParticipantInfo_Kind` and `KindDetails` set alongside the existing string-valued `Kind`.
- Add `ParticipantKindCode` and `ParticipantKindDetailsCodes` helpers (zero-alloc reinterpret for the details slice).
- Bumped schema version to `1HUONO8` to match cloud-observability/pull/468.

## Test plan
- [ ] `go build ./...` in protocol
- [ ] livekit and cloud consumers compile against this version