### PR TITLE
Add prometheus metrics to ConfigObserver

### DIFF
--- a/.changeset/bitter-mails-enter.md
+++ b/.changeset/bitter-mails-enter.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+Add prometheus metrics to ConfigObserver

--- a/utils/configobserver.go
+++ b/utils/configobserver.go
@@ -16,9 +16,12 @@ package utils
 
 import (
 	"fmt"
+	"hash/crc32"
 	"os"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/atomic"
 	"gopkg.in/yaml.v3"
 
@@ -119,9 +122,11 @@ func (c *ConfigObserver[T]) watch() {
 func (c *ConfigObserver[T]) reload(path string) error {
 	conf, err := c.load(path)
 	if err != nil {
+		recordConfigReload(path, false)
 		return err
 	}
 
+	recordConfigReload(path, true)
 	c.EmitConfigUpdate(conf)
 	return nil
 }
@@ -132,6 +137,8 @@ func (c *ConfigObserver[T]) load(path string) (*T, error) {
 		return nil, err
 	}
 
+	var hash uint32
+	hasHash := false
 	if path != "" {
 		b, err := os.ReadFile(path)
 		if err != nil {
@@ -145,6 +152,9 @@ func (c *ConfigObserver[T]) load(path string) (*T, error) {
 		if err := yaml.Unmarshal(b, conf); err != nil {
 			return nil, fmt.Errorf("cannot parse config: %v", err)
 		}
+
+		hash = configHash(b)
+		hasHash = true
 	}
 
 	if d, ok := c.builder.(ConfigDefaulter[T]); ok {
@@ -153,5 +163,44 @@ func (c *ConfigObserver[T]) load(path string) (*T, error) {
 
 	c.conf.Store(conf)
 
+	if hasHash {
+		setConfigHash(path, hash)
+	}
+
 	return conf, err
+}
+
+var (
+	promConfigReloadTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "livekit",
+		Subsystem: "config",
+		Name:      "reload_total",
+		Help:      "Number of times the config file has been reloaded, labeled by file and whether the reload succeeded",
+	}, []string{"file", "status"})
+
+	promConfigHash = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "livekit",
+		Subsystem: "config",
+		Name:      "hash",
+		Help:      "Short checksum of the config file currently in use, for detecting changes. Not updated when a reload fails",
+	}, []string{"file"})
+)
+
+// configHash returns a small checksum of the config bytes, used only to detect
+// when the config content changes (not for any security purpose).
+func configHash(b []byte) uint32 {
+	return crc32.ChecksumIEEE(b) % 1_000_000
+}
+
+func recordConfigReload(file string, success bool) {
+	status := "success"
+	if !success {
+		status = "failure"
+	}
+	promConfigReloadTotal.WithLabelValues(file, status).Inc()
+}
+
+// setConfigHash publishes the checksum of the config currently in use for file.
+func setConfigHash(file string, hash uint32) {
+	promConfigHash.WithLabelValues(file).Set(float64(hash))
 }

--- a/utils/configobserver_test.go
+++ b/utils/configobserver_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/protocol/utils/configutil"
@@ -26,6 +28,7 @@ import (
 
 const testConfig0 = `foo: a`
 const testConfig1 = `foo: b`
+const testConfigInvalid = `foo: [unterminated`
 
 type TestConfig struct {
 	Foo string `yaml:"foo"`
@@ -54,6 +57,7 @@ func TestConfigObserver(t *testing.T) {
 
 	obs, conf, err := NewConfigObserver(f.Name(), testConfigBuilder{})
 	require.NoError(t, err)
+	t.Cleanup(obs.Close)
 
 	require.Equal(t, "a", conf.Foo)
 	require.Equal(t, "c", conf.Bar)
@@ -63,6 +67,13 @@ func TestConfigObserver(t *testing.T) {
 	})
 
 	require.Equal(t, "a", atomicFoo.Load())
+
+	// the initial load publishes the config hash but does not count as a reload
+	require.Zero(t, counterVecValue(promConfigReloadTotal, f.Name(), "success"))
+	require.Equal(t,
+		float64(configHash([]byte(testConfig0))),
+		gaugeVecValue(promConfigHash, f.Name()),
+	)
 
 	done := make(chan struct{})
 	obs.Observe(func(c *TestConfig) {
@@ -81,4 +92,46 @@ func TestConfigObserver(t *testing.T) {
 	}
 
 	require.Equal(t, "b", atomicFoo.Load())
+
+	// the reload is counted and the hash gauge tracks the new config
+	require.Equal(t, float64(1), counterVecValue(promConfigReloadTotal, f.Name(), "success"))
+	require.Equal(t,
+		float64(configHash([]byte(testConfig1))),
+		gaugeVecValue(promConfigHash, f.Name()),
+	)
+
+	_, err = f.WriteAt([]byte(testConfigInvalid), 0)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return counterVecValue(promConfigReloadTotal, f.Name(), "failure") == 1
+	}, time.Second, 5*time.Millisecond)
+	require.Equal(t,
+		float64(configHash([]byte(testConfig1))),
+		gaugeVecValue(promConfigHash, f.Name()),
+	)
+}
+
+func gaugeVecValue(g *prometheus.GaugeVec, labels ...string) float64 {
+	m, err := g.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+	var dtoM dto.Metric
+	if err := m.Write(&dtoM); err != nil {
+		return 0
+	}
+	return dtoM.GetGauge().GetValue()
+}
+
+func counterVecValue(c *prometheus.CounterVec, labels ...string) float64 {
+	m, err := c.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+	var dtoM dto.Metric
+	if err := m.Write(&dtoM); err != nil {
+		return 0
+	}
+	return dtoM.GetCounter().GetValue()
 }


### PR DESCRIPTION
This PR introduces the following prometheus metrics:

* `livekit_config_reload_total`: total number of config reloads, including failures.
* `livekit_config_hash`: checksum of the last successfully loaded config.