### PR TITLE
Add one additional prometheus metric for the ConfigObserver

### DIFF
--- a/utils/configobserver.go
+++ b/utils/configobserver.go
@@ -131,8 +131,14 @@ func (c *ConfigObserver[T]) reload(path string) error {
 	return nil
 }
 
-func (c *ConfigObserver[T]) load(path string) (*T, error) {
-	conf, err := c.builder.New()
+func (c *ConfigObserver[T]) load(path string) (conf *T, err error) {
+	// always record the load outcome so livekit_config_load_state is populated
+	// from the initial load onward and flips on every subsequent load attempt.
+	if path != "" {
+		defer func() { setConfigLoadState(path, err != nil) }()
+	}
+
+	conf, err = c.builder.New()
 	if err != nil {
 		return nil, err
 	}
@@ -184,6 +190,13 @@ var (
 		Name:      "hash",
 		Help:      "Short checksum of the config file currently in use, for detecting changes. Not updated when a reload fails",
 	}, []string{"file"})
+
+	promConfigLoadState = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "livekit",
+		Subsystem: "config",
+		Name:      "load_state",
+		Help:      "0 when the config file last loaded successfully, 1 when the last load failed.",
+	}, []string{"file"})
 )
 
 // configHash returns a small checksum of the config bytes, used only to detect
@@ -198,6 +211,16 @@ func recordConfigReload(file string, success bool) {
 		status = "failure"
 	}
 	promConfigReloadTotal.WithLabelValues(file, status).Inc()
+}
+
+// setConfigLoadState publishes whether the most recent load of file failed:
+// 0 on success, 1 on failure.
+func setConfigLoadState(file string, failed bool) {
+	v := 0.0
+	if failed {
+		v = 1
+	}
+	promConfigLoadState.WithLabelValues(file).Set(v)
 }
 
 // setConfigHash publishes the checksum of the config currently in use for file.

--- a/utils/configobserver_test.go
+++ b/utils/configobserver_test.go
@@ -29,6 +29,7 @@ import (
 const testConfig0 = `foo: a`
 const testConfig1 = `foo: b`
 const testConfigInvalid = `foo: [unterminated`
+const testConfig1Recover = `foo: b # recovered after invalid`
 
 type TestConfig struct {
 	Foo string `yaml:"foo"`
@@ -68,15 +69,17 @@ func TestConfigObserver(t *testing.T) {
 
 	require.Equal(t, "a", atomicFoo.Load())
 
-	// the initial load publishes the config hash but does not count as a reload
+	// the initial load publishes the config hash but does not count as a reload,
+	// and the load state is populated as healthy (0) from the start
 	require.Zero(t, counterVecValue(promConfigReloadTotal, f.Name(), "success"))
 	require.Equal(t,
 		float64(configHash([]byte(testConfig0))),
 		gaugeVecValue(promConfigHash, f.Name()),
 	)
+	require.Zero(t, gaugeVecValue(promConfigLoadState, f.Name()))
 
 	done := make(chan struct{})
-	obs.Observe(func(c *TestConfig) {
+	unsubscribe := obs.Observe(func(c *TestConfig) {
 		require.Equal(t, "b", c.Foo)
 		require.Equal(t, "c", c.Bar)
 		close(done)
@@ -93,12 +96,17 @@ func TestConfigObserver(t *testing.T) {
 
 	require.Equal(t, "b", atomicFoo.Load())
 
-	// the reload is counted and the hash gauge tracks the new config
+	// the reload is counted, the hash gauge tracks the new config, and the load
+	// state stays healthy (0)
 	require.Equal(t, float64(1), counterVecValue(promConfigReloadTotal, f.Name(), "success"))
 	require.Equal(t,
 		float64(configHash([]byte(testConfig1))),
 		gaugeVecValue(promConfigHash, f.Name()),
 	)
+	require.Zero(t, gaugeVecValue(promConfigLoadState, f.Name()))
+
+	// stop the one-shot observer above; the remaining writes don't expect it
+	unsubscribe()
 
 	_, err = f.WriteAt([]byte(testConfigInvalid), 0)
 	require.NoError(t, err)
@@ -110,6 +118,16 @@ func TestConfigObserver(t *testing.T) {
 		float64(configHash([]byte(testConfig1))),
 		gaugeVecValue(promConfigHash, f.Name()),
 	)
+	require.Equal(t, float64(1), gaugeVecValue(promConfigLoadState, f.Name()))
+
+	// a subsequent valid load clears the failure state back to 0
+	_, err = f.WriteAt([]byte(testConfig1Recover), 0)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return counterVecValue(promConfigReloadTotal, f.Name(), "success") == 2
+	}, time.Second, 5*time.Millisecond)
+	require.Zero(t, gaugeVecValue(promConfigLoadState, f.Name()))
 }
 
 func gaugeVecValue(g *prometheus.GaugeVec, labels ...string) float64 {


### PR DESCRIPTION
While the metrics added in #1602 are useful for dashboards, this one can easily be used in alerts as well.