### PR TITLE
Add item_id to UserInputTranscribed protobuf

### DIFF
--- a/livekit/agent/livekit_agent_session.pb.go
+++ b/livekit/agent/livekit_agent_session.pb.go
@@ -2860,6 +2860,7 @@ type AgentSessionEvent_UserInputTranscribed struct {
 	Transcript    string                 `protobuf:"bytes,1,opt,name=transcript,proto3" json:"transcript,omitempty"`
 	IsFinal       bool                   `protobuf:"varint,2,opt,name=is_final,json=isFinal,proto3" json:"is_final,omitempty"`
 	Language      *string                `protobuf:"bytes,3,opt,name=language,proto3,oneof" json:"language,omitempty"`
+	ItemId        string                 `protobuf:"bytes,4,opt,name=item_id,json=itemId,proto3" json:"item_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2911,6 +2912,13 @@ func (x *AgentSessionEvent_UserInputTranscribed) GetIsFinal() bool {
 func (x *AgentSessionEvent_UserInputTranscribed) GetLanguage() string {
 	if x != nil && x.Language != nil {
 		return *x.Language
+	}
+	return ""
+}
+
+func (x *AgentSessionEvent_UserInputTranscribed) GetItemId() string {
+	if x != nil {
+		return x.ItemId
 	}
 	return ""
 }

--- a/protobufs/agent/livekit_agent_session.proto
+++ b/protobufs/agent/livekit_agent_session.proto
@@ -222,6 +222,7 @@ message AgentSessionEvent {
     string transcript = 1;
     bool is_final = 2;
     optional string language = 3;
+    string item_id = 4;
   }
 
   message FunctionToolsStarted {


### PR DESCRIPTION
Fixes #1641
This PR adds `item_id` to the `UserInputTranscribed` protobuf message and propagates it through the remote session transport.

This change is a follow-up to livekit-agents#6109, which exposes `item_id` on `UserInputTranscribedEvent` so consumers can correlate interim and final transcription updates belonging to the same user utterance. While that change makes `item_id` available to local consumers, the remote session transport currently drops this information because the protobuf schema only includes `transcript` and `is_final`.

Without this update, applications using remote sessions cannot reliably correlate transcription updates, deduplicate interim transcripts, or react exactly once per utterance, leading to inconsistent behavior between local and remote deployments.

Changes

- Add `item_id` to the `UserInputTranscribed` protobuf message.
- Forward `item_id` through the remote session transport.
- Preserve utterance correlation metadata across local and remote session boundaries.

Benefits

Remote session consumers can now:
- Correlate interim and final transcripts belonging to the same utterance.
- Deduplicate transcription updates using a stable identifier.
- React exactly once per utterance.
- Use the same logic across local and remote session deployments.

Related to livekit/agents#6109