### PR TITLE
Relax SIP codec validation.

### DIFF
--- a/.changeset/sip-codec-validation.md
+++ b/.changeset/sip-codec-validation.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+Relax SIP codec validation.

--- a/livekit/sip.go
+++ b/livekit/sip.go
@@ -1064,9 +1064,6 @@ func (p *SIPCodec) Validate() error {
 	if strings.Contains(p.Name, "/") {
 		return errors.New("codec name must not contain '/'")
 	}
-	if p.Rate == 0 {
-		return errors.New("invalid codec sample rate")
-	}
 	return nil
 }
 


### PR DESCRIPTION
Allow omitting codec sample rate. SIP server already sets it to a default value, if missing.