### PR TITLE
Fix recursive call to validate.

### DIFF
--- a/.changeset/brave-coats-give.md
+++ b/.changeset/brave-coats-give.md
@@ -1,0 +1,6 @@
+---
+"github.com/livekit/protocol": patch
+"@livekit/protocol": patch
+---
+
+Fix recursive call to CreateSIPInboundTrunkRequest.ValidateResult.

--- a/livekit/sip.go
+++ b/livekit/sip.go
@@ -441,7 +441,7 @@ func (p *CreateSIPInboundTrunkRequest) ValidateResult() ValidationResult {
 	if p.Trunk.SipTrunkId != "" {
 		return ValidationFailure(errors.New("trunk id must not be set"))
 	}
-	return p.ValidateResult()
+	return p.Trunk.ValidateResult()
 }
 
 func (p *UpdateSIPOutboundTrunkRequest) Validate() error {

--- a/livekit/sip.go
+++ b/livekit/sip.go
@@ -365,15 +365,18 @@ func ValidationFailure(err error) ValidationResult {
 }
 
 func validateHeaders(headers map[string]string) ValidationResult {
+	ret := ValidationResult{}
 	for headerName, headerValue := range headers {
 		if err := ValidateHeaderName(headerName, true); err != nil {
-			return ValidationFailure(fmt.Errorf("invalid header name: %w", err))
+			return ret.WithError(fmt.Errorf("invalid header name: %w", err))
 		}
-		if err := ValidateHeaderValue(headerName, headerValue); err != nil {
-			return ValidationFailure(fmt.Errorf("invalid header value for %s: %w", headerName, err))
+		result := ValidateHeaderValueResult(headerName, headerValue)
+		if !result.OK() {
+			return ret.WithError(fmt.Errorf("invalid header value for %s: %w", headerName, result.Error()))
 		}
+		ret = ret.Combine(result)
 	}
-	return ValidationResult{}
+	return ret
 }
 
 // validateHeaderNames Makes sure the values of the given map correspond to valid SIP header names

--- a/livekit/sip_test.go
+++ b/livekit/sip_test.go
@@ -228,7 +228,7 @@ func TestSIPValidate(t *testing.T) {
 					},
 				},
 				exp:          true,
-				wantSoftErrs: false,
+				wantSoftErrs: true,
 			},
 		},
 		"SIPMediaConfig": {

--- a/livekit/sip_test.go
+++ b/livekit/sip_test.go
@@ -2,6 +2,7 @@ package livekit
 
 import (
 	errors "errors"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -50,11 +51,16 @@ func TestSIPValidate(t *testing.T) {
 	type validateable interface {
 		Validate() error
 	}
+	type resultValidateable interface {
+		ValidateResult() ValidationResult
+	}
+
 	type validateTestCase struct {
 		name string
 		req  validateable
 		exp  bool
 	}
+
 	cases := map[string][]validateTestCase{
 		"SIPInboundTrunkInfo": {
 			{
@@ -322,7 +328,193 @@ func TestSIPValidate(t *testing.T) {
 				exp: false,
 			},
 		},
+		"CreateSIPInboundTrunkRequest": {
+			{
+				name: "create_inbound_missing_trunk",
+				req:  &CreateSIPInboundTrunkRequest{},
+				exp:  false,
+			},
+			{
+				name: "create_inbound_trunk_id_set",
+				req: &CreateSIPInboundTrunkRequest{
+					Trunk: &SIPInboundTrunkInfo{
+						SipTrunkId: "id",
+						Numbers:    []string{"+1111"},
+					},
+				},
+				exp: false,
+			},
+			{
+				name: "create_inbound_valid",
+				req: &CreateSIPInboundTrunkRequest{
+					Trunk: &SIPInboundTrunkInfo{
+						Numbers: []string{"+1111"},
+					},
+				},
+				exp: true,
+			},
+		},
+		"CreateSIPOutboundTrunkRequest": {
+			{
+				name: "create_outbound_missing_trunk",
+				req:  &CreateSIPOutboundTrunkRequest{},
+				exp:  false,
+			},
+			{
+				name: "create_outbound_trunk_id_set",
+				req: &CreateSIPOutboundTrunkRequest{
+					Trunk: &SIPOutboundTrunkInfo{
+						SipTrunkId: "id",
+					},
+				},
+				exp: false,
+			},
+			{
+				name: "create_outbound_valid",
+				req: &CreateSIPOutboundTrunkRequest{
+					Trunk: &SIPOutboundTrunkInfo{
+						Address: "sip.example.com",
+						Numbers: []string{"+2222"},
+					},
+				},
+				exp: true,
+			},
+		},
+		"UpdateSIPInboundTrunkRequest": {
+			{
+				name: "update_inbound_missing_id",
+				req:  &UpdateSIPInboundTrunkRequest{},
+				exp:  false,
+			},
+			{
+				name: "update_inbound_missing_action",
+				req: &UpdateSIPInboundTrunkRequest{
+					SipTrunkId: "id",
+				},
+				exp: false,
+			},
+			{
+				name: "update_inbound_update_ok",
+				req: &UpdateSIPInboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPInboundTrunkRequest_Update{
+						Update: &SIPInboundTrunkUpdate{},
+					},
+				},
+				exp: true,
+			},
+			{
+				name: "update_inbound_replace_ok",
+				req: &UpdateSIPInboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPInboundTrunkRequest_Replace{
+						Replace: &SIPInboundTrunkInfo{
+							Numbers: []string{"+1111"},
+						},
+					},
+				},
+				exp: true,
+			},
+			{
+				name: "update_inbound_replace_id_mismatch",
+				req: &UpdateSIPInboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPInboundTrunkRequest_Replace{
+						Replace: &SIPInboundTrunkInfo{
+							SipTrunkId: "other",
+							Numbers:    []string{"+1111"},
+						},
+					},
+				},
+				exp: false,
+			},
+		},
+		"UpdateSIPOutboundTrunkRequest": {
+			{
+				name: "update_outbound_missing id",
+				req:  &UpdateSIPOutboundTrunkRequest{},
+				exp:  false,
+			},
+			{
+				name: "update_outbound_missing_action",
+				req: &UpdateSIPOutboundTrunkRequest{
+					SipTrunkId: "id",
+				},
+				exp: false,
+			},
+			{
+				name: "update_outbound_update_ok",
+				req: &UpdateSIPOutboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPOutboundTrunkRequest_Update{
+						Update: &SIPOutboundTrunkUpdate{},
+					},
+				},
+				exp: true,
+			},
+			{
+				name: "update_outbound_replace_ok",
+				req: &UpdateSIPOutboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPOutboundTrunkRequest_Replace{
+						Replace: &SIPOutboundTrunkInfo{
+							Address: "sip.example.com",
+							Numbers: []string{"+2222"},
+						},
+					},
+				},
+				exp: true,
+			},
+			{
+				name: "update_outbound_replace_id_mismatch",
+				req: &UpdateSIPOutboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPOutboundTrunkRequest_Replace{
+						Replace: &SIPOutboundTrunkInfo{
+							SipTrunkId: "other",
+							Address:    "sip.example.com",
+							Numbers:    []string{"+2222"},
+						},
+					},
+				},
+				exp: false,
+			},
+		},
+		"TransferSIPParticipantRequest": {
+			{
+				name: "transfer_valid",
+				req: &TransferSIPParticipantRequest{
+					RoomName:            "room1",
+					ParticipantIdentity: "participant1",
+					TransferTo:          "tel:+15105550100",
+				},
+				exp: true,
+			},
+			{
+				name: "transfer_missing_room",
+				req:  &TransferSIPParticipantRequest{},
+				exp:  false,
+			},
+			{
+				name: "transfer_missing_participant",
+				req: &TransferSIPParticipantRequest{
+					RoomName: "room1",
+				},
+				exp: false,
+			},
+			{
+				name: "transfer_invalid_uri",
+				req: &TransferSIPParticipantRequest{
+					RoomName:            "room1",
+					ParticipantIdentity: "participant1",
+					TransferTo:          "http://example.com",
+				},
+				exp: false,
+			},
+		},
 	}
+
+	resultValidatableTypes := make(map[string]bool)
 
 	for name, class := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -330,10 +522,28 @@ func TestSIPValidate(t *testing.T) {
 				t.Run(c.name, func(t *testing.T) {
 					err := c.req.Validate()
 					require.Equal(t, c.exp, err == nil, "error: %v", err)
+
+					if v, ok := c.req.(resultValidateable); ok {
+						result := v.ValidateResult()
+						require.Equal(t, c.exp, result.Error() == nil, "error: %v", err)
+						resultValidatableTypes[fmt.Sprintf("%T", v)] = true
+					}
 				})
 			}
 		})
 	}
+
+	wantResultValidateableTypes := map[string]bool{
+		"*livekit.CreateSIPInboundTrunkRequest":  true,
+		"*livekit.CreateSIPOutboundTrunkRequest": true,
+		"*livekit.CreateSIPParticipantRequest":   true,
+		"*livekit.SIPInboundTrunkInfo":           true,
+		"*livekit.SIPOutboundTrunkInfo":          true,
+		"*livekit.TransferSIPParticipantRequest": true,
+		"*livekit.UpdateSIPInboundTrunkRequest":  true,
+		"*livekit.UpdateSIPOutboundTrunkRequest": true,
+	}
+	require.Equal(t, wantResultValidateableTypes, resultValidatableTypes)
 }
 
 func TestSIPInboundTrunkFilter(t *testing.T) {

--- a/livekit/sip_test.go
+++ b/livekit/sip_test.go
@@ -55,9 +55,10 @@ func TestSIPValidate(t *testing.T) {
 		ValidateResult() ValidationResult
 	}
 	type validateTestCase struct {
-		name string
-		req  validateable
-		exp  bool
+		name         string
+		req          validateable
+		exp          bool
+		wantSoftErrs bool
 	}
 
 	cases := map[string][]validateTestCase{
@@ -118,6 +119,27 @@ func TestSIPValidate(t *testing.T) {
 					},
 				},
 				exp: false,
+			},
+			{
+				name: "inbound invalid header",
+				req: &SIPInboundTrunkInfo{
+					Numbers: []string{"+1111"},
+					HeadersToAttributes: map[string]string{
+						"From ": "from",
+					},
+				},
+				exp: false,
+			},
+			{
+				name: "inbound invalid header value",
+				req: &SIPInboundTrunkInfo{
+					Numbers: []string{"+1111"},
+					HeadersToAttributes: map[string]string{
+						"From": "<sip:u7@example.com", // missing closing bracket
+					},
+				},
+				exp:          true,
+				wantSoftErrs: true,
 			},
 		},
 		"SIPOutboundTrunkInfo": {
@@ -205,6 +227,18 @@ func TestSIPValidate(t *testing.T) {
 					},
 				},
 				exp: false,
+			},
+			{
+				name: "outbound invalid header value",
+				req: &SIPOutboundTrunkInfo{
+					Address: "sip.example.com",
+					Numbers: []string{"+2222"},
+					HeadersToAttributes: map[string]string{
+						"From": "<sip:u7@example.com", // missing closing bracket
+					},
+				},
+				exp:          true,
+				wantSoftErrs: true,
 			},
 		},
 		"SIPMediaConfig": {
@@ -326,6 +360,20 @@ func TestSIPValidate(t *testing.T) {
 				},
 				exp: false,
 			},
+			{
+				name: "invalid_header_value_soft_failure",
+				req: &CreateSIPParticipantRequest{
+					SipTrunkId: "trunk",
+					SipCallTo:  "+1000",
+					RoomName:   "room",
+					Headers: map[string]string{
+						"From": "<sip:u7@example.com", // missing closing bracket
+					},
+					// Sanity
+				},
+				exp:          true,
+				wantSoftErrs: true,
+			},
 		},
 		"CreateSIPInboundTrunkRequest": {
 			{
@@ -352,6 +400,19 @@ func TestSIPValidate(t *testing.T) {
 				},
 				exp: true,
 			},
+			{
+				name: "create_inbound_valid_soft_failure",
+				req: &CreateSIPInboundTrunkRequest{
+					Trunk: &SIPInboundTrunkInfo{
+						Numbers: []string{"+1111"},
+						Headers: map[string]string{
+							"From": "<sip:u7@example.com", // missing closing bracket
+						},
+					},
+				},
+				exp:          true,
+				wantSoftErrs: true,
+			},
 		},
 		"CreateSIPOutboundTrunkRequest": {
 			{
@@ -377,6 +438,20 @@ func TestSIPValidate(t *testing.T) {
 					},
 				},
 				exp: true,
+			},
+			{
+				name: "create_outbound_valid_soft_failure",
+				req: &CreateSIPOutboundTrunkRequest{
+					Trunk: &SIPOutboundTrunkInfo{
+						Address: "sip.example.com",
+						Numbers: []string{"+2222"},
+						Headers: map[string]string{
+							"From": "<sip:u7@example.com", // missing closing bracket
+						},
+					},
+				},
+				exp:          true,
+				wantSoftErrs: true,
 			},
 		},
 		"UpdateSIPInboundTrunkRequest": {
@@ -413,6 +488,22 @@ func TestSIPValidate(t *testing.T) {
 					},
 				},
 				exp: true,
+			},
+			{
+				name: "update_inbound_replace_ok_soft_failrues",
+				req: &UpdateSIPInboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPInboundTrunkRequest_Replace{
+						Replace: &SIPInboundTrunkInfo{
+							Numbers: []string{"+1111"},
+							Headers: map[string]string{
+								"From": "<sip:u7@example.com", // missing closing bracket
+							},
+						},
+					},
+				},
+				exp:          true,
+				wantSoftErrs: true,
 			},
 			{
 				name: "update_inbound_replace_id_mismatch",
@@ -465,6 +556,23 @@ func TestSIPValidate(t *testing.T) {
 				exp: true,
 			},
 			{
+				name: "update_outbound_replace_ok_soft_failures",
+				req: &UpdateSIPOutboundTrunkRequest{
+					SipTrunkId: "id",
+					Action: &UpdateSIPOutboundTrunkRequest_Replace{
+						Replace: &SIPOutboundTrunkInfo{
+							Address: "sip.example.com",
+							Numbers: []string{"+2222"},
+							Headers: map[string]string{
+								"From": "<sip:u7@example.com", // missing closing bracket
+							},
+						},
+					},
+				},
+				exp:          true,
+				wantSoftErrs: true,
+			},
+			{
 				name: "update_outbound_replace_id_mismatch",
 				req: &UpdateSIPOutboundTrunkRequest{
 					SipTrunkId: "id",
@@ -482,6 +590,19 @@ func TestSIPValidate(t *testing.T) {
 		"TransferSIPParticipantRequest": {
 			{
 				name: "transfer_valid",
+				req: &TransferSIPParticipantRequest{
+					RoomName:            "room1",
+					ParticipantIdentity: "participant1",
+					TransferTo:          "tel:+15105550100",
+					Headers: map[string]string{
+						"From": "<sip:u7@example.com",
+					},
+				},
+				exp:          true,
+				wantSoftErrs: true,
+			},
+			{
+				name: "transfer_valid_soft_failures",
 				req: &TransferSIPParticipantRequest{
 					RoomName:            "room1",
 					ParticipantIdentity: "participant1",
@@ -526,6 +647,13 @@ func TestSIPValidate(t *testing.T) {
 						result := v.ValidateResult()
 						require.Equal(t, c.exp, result.Error() == nil, "error: %v", err)
 						resultValidatableTypes[fmt.Sprintf("%T", v)] = true
+
+						hasSoftErrs := len(result.SoftErrors()) > 0
+						if c.wantSoftErrs {
+							require.Equal(t, c.wantSoftErrs, hasSoftErrs, "got zero soft validation errors; want at least one")
+						} else {
+							require.Equal(t, c.wantSoftErrs, hasSoftErrs, "got at least one soft validation error; want zero; %v", result.SoftErrors())
+						}
 					}
 				})
 			}

--- a/livekit/sip_test.go
+++ b/livekit/sip_test.go
@@ -1,7 +1,7 @@
 package livekit
 
 import (
-	errors "errors"
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
@@ -121,21 +121,11 @@ func TestSIPValidate(t *testing.T) {
 				exp: false,
 			},
 			{
-				name: "inbound invalid header",
-				req: &SIPInboundTrunkInfo{
-					Numbers: []string{"+1111"},
-					HeadersToAttributes: map[string]string{
-						"From ": "from",
-					},
-				},
-				exp: false,
-			},
-			{
 				name: "inbound invalid header value",
 				req: &SIPInboundTrunkInfo{
 					Numbers: []string{"+1111"},
-					HeadersToAttributes: map[string]string{
-						"From": "<sip:u7@example.com", // missing closing bracket
+					Headers: map[string]string{
+						"Referred-By": "<sip:u7@example.com", // missing closing bracket
 					},
 				},
 				exp:          true,
@@ -233,12 +223,12 @@ func TestSIPValidate(t *testing.T) {
 				req: &SIPOutboundTrunkInfo{
 					Address: "sip.example.com",
 					Numbers: []string{"+2222"},
-					HeadersToAttributes: map[string]string{
-						"From": "<sip:u7@example.com", // missing closing bracket
+					Headers: map[string]string{
+						"Referred-By": "<sip:u7@example.com", // missing closing bracket
 					},
 				},
 				exp:          true,
-				wantSoftErrs: true,
+				wantSoftErrs: false,
 			},
 		},
 		"SIPMediaConfig": {
@@ -367,7 +357,7 @@ func TestSIPValidate(t *testing.T) {
 					SipCallTo:  "+1000",
 					RoomName:   "room",
 					Headers: map[string]string{
-						"From": "<sip:u7@example.com", // missing closing bracket
+						"Referred-By": "<sip:u7@example.com", // missing closing bracket
 					},
 					// Sanity
 				},
@@ -406,7 +396,7 @@ func TestSIPValidate(t *testing.T) {
 					Trunk: &SIPInboundTrunkInfo{
 						Numbers: []string{"+1111"},
 						Headers: map[string]string{
-							"From": "<sip:u7@example.com", // missing closing bracket
+							"Referred-By": "<sip:u7@example.com", // missing closing bracket
 						},
 					},
 				},
@@ -446,7 +436,7 @@ func TestSIPValidate(t *testing.T) {
 						Address: "sip.example.com",
 						Numbers: []string{"+2222"},
 						Headers: map[string]string{
-							"From": "<sip:u7@example.com", // missing closing bracket
+							"Referred-By": "<sip:u7@example.com", // missing closing bracket
 						},
 					},
 				},
@@ -497,7 +487,7 @@ func TestSIPValidate(t *testing.T) {
 						Replace: &SIPInboundTrunkInfo{
 							Numbers: []string{"+1111"},
 							Headers: map[string]string{
-								"From": "<sip:u7@example.com", // missing closing bracket
+								"Referred-By": "<sip:u7@example.com", // missing closing bracket
 							},
 						},
 					},
@@ -564,7 +554,7 @@ func TestSIPValidate(t *testing.T) {
 							Address: "sip.example.com",
 							Numbers: []string{"+2222"},
 							Headers: map[string]string{
-								"From": "<sip:u7@example.com", // missing closing bracket
+								"Referred-By": "<sip:u7@example.com", // missing closing bracket
 							},
 						},
 					},
@@ -594,12 +584,8 @@ func TestSIPValidate(t *testing.T) {
 					RoomName:            "room1",
 					ParticipantIdentity: "participant1",
 					TransferTo:          "tel:+15105550100",
-					Headers: map[string]string{
-						"From": "<sip:u7@example.com",
-					},
 				},
-				exp:          true,
-				wantSoftErrs: true,
+				exp: true,
 			},
 			{
 				name: "transfer_valid_soft_failures",
@@ -607,8 +593,12 @@ func TestSIPValidate(t *testing.T) {
 					RoomName:            "room1",
 					ParticipantIdentity: "participant1",
 					TransferTo:          "tel:+15105550100",
+					Headers: map[string]string{
+						"Referred-By": "<sip:u7@example.com", // missing closing bracket
+					},
 				},
-				exp: true,
+				exp:          true,
+				wantSoftErrs: true,
 			},
 			{
 				name: "transfer_missing_room",
@@ -1466,6 +1456,60 @@ func TestValidationResultCombine(t *testing.T) {
 				require.ErrorContains(t, result.Error(), testCase.other.Error().Error())
 			}
 			require.Equal(t, result.SoftErrors(), testCase.expected.SoftErrors())
+		})
+	}
+}
+
+func errMsgs(errs []error) []string {
+	ret := make([]string, 0, len(errs))
+	for _, err := range errs {
+		ret = append(ret, err.Error())
+	}
+	return ret
+}
+
+func TestValidateHeaders(t *testing.T) {
+	type testCase struct {
+		name     string
+		headers  map[string]string
+		expected ValidationResult
+	}
+
+	testCases := []testCase{
+		{
+			name:     "empty headers",
+			headers:  map[string]string{},
+			expected: ValidationResult{},
+		},
+		{
+			name: "valid header",
+			headers: map[string]string{
+				"Reffered-By": "<sip:u7@example.com",
+			},
+			expected: ValidationResult{},
+		},
+		{
+			name: "multiple soft failures",
+			headers: map[string]string{
+				"P-Asserted-Identity": "<",
+				"Referred-By":         "<",
+			},
+			expected: ValidationResult{softErrs: []error{
+				errors.New("header P-Asserted-Identity: value: mismatched angle brackets"),
+				errors.New("header Referred-By: value: mismatched angle brackets"),
+			}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := validateHeaders(testCase.headers)
+			if testCase.expected.Error() != nil {
+				require.Error(t, result.Error())
+			} else {
+				require.NoError(t, result.Error())
+			}
+			require.Equal(t, len(testCase.expected.SoftErrors()), len(result.SoftErrors()), "soft error slice lengths differ; got soft errors: %v", result.SoftErrors())
 		})
 	}
 }

--- a/livekit/sip_test.go
+++ b/livekit/sip_test.go
@@ -54,7 +54,6 @@ func TestSIPValidate(t *testing.T) {
 	type resultValidateable interface {
 		ValidateResult() ValidationResult
 	}
-
 	type validateTestCase struct {
 		name string
 		req  validateable

--- a/livekit/sip_validation.go
+++ b/livekit/sip_validation.go
@@ -169,7 +169,7 @@ var RequiredResponseHeaders = map[string]bool{
 }
 
 // Crucial headers that can't be overridden by the user, and their shorthands
-var FrobiddenSipHeaderNames = map[string]bool{
+var ForbiddenSipHeaderNames = map[string]bool{
 	"accept":           true,
 	"accept-encoding":  true,
 	"accept-language":  true,
@@ -232,7 +232,7 @@ func ValidateHeaderName(name string, restrictNames bool) error {
 	// Convert to lowercase for case-insensitive comparison
 	if restrictNames {
 		lowerName := strings.ToLower(name)
-		if forbidden, exists := FrobiddenSipHeaderNames[lowerName]; exists && forbidden {
+		if forbidden, exists := ForbiddenSipHeaderNames[lowerName]; exists && forbidden {
 			return fmt.Errorf("header name %s not supported", name)
 		}
 	}

--- a/livekit/sip_validation_test.go
+++ b/livekit/sip_validation_test.go
@@ -292,9 +292,9 @@ func TestValidateHeaderValueResult(t *testing.T) {
 	}
 }
 
-func TestFrobiddenSipHeaderNames(t *testing.T) {
+func TestForbiddenSipHeaderNames(t *testing.T) {
 	i := 0
-	for name := range FrobiddenSipHeaderNames {
+	for name := range ForbiddenSipHeaderNames {
 		i++
 		t.Run(testCaseName(name, 32, i), func(t *testing.T) {
 			err := ValidateHeaderName(name, true)


### PR DESCRIPTION
- Fix `CreateSIPInboundTrunkRequest.ValidateResult()` (currently, it calls itself).
- Extend `TestSIPValidate` to also test these `ValidateResult` method implementations (and add some new test cases).
- Add a few additional tests.