### PR TITLE
js: export the agent simulation protos from the package root

### DIFF
--- a/.changeset/export-agent-simulation-proto.md
+++ b/.changeset/export-agent-simulation-proto.md
@@ -1,0 +1,5 @@
+---
+"@livekit/protocol": patch
+---
+
+Export the agent simulation protos (Scenario, SimulationDispatch, SimulationMode, SimulationRun, ...) from the JS package root

--- a/packages/javascript/src/index.d.ts
+++ b/packages/javascript/src/index.d.ts
@@ -6,6 +6,7 @@ export * as AgentText from "./gen/agent/livekit_agent_text_pb.js";
 export * as AgentDev from "./gen/agent/livekit_agent_dev_pb.js";
 export * from "./gen/livekit_agent_dispatch_pb.js";
 export * from "./gen/livekit_agent_pb.js";
+export * from "./gen/livekit_agent_simulation_pb.js";
 export * from "./gen/livekit_analytics_pb.js";
 export * from "./gen/livekit_connector_pb.js";
 export * from "./gen/livekit_connector_twilio_pb.js";

--- a/packages/javascript/src/index.js
+++ b/packages/javascript/src/index.js
@@ -7,6 +7,7 @@ export * as AgentText from "./gen/agent/livekit_agent_text_pb.js";
 export * as AgentDev from "./gen/agent/livekit_agent_dev_pb.js";
 export * from "./gen/livekit_agent_dispatch_pb.js";
 export * from "./gen/livekit_agent_pb.js";
+export * from "./gen/livekit_agent_simulation_pb.js";
 export * from "./gen/livekit_analytics_pb.js";
 export * from "./gen/livekit_connector_pb.js";
 export * from "./gen/livekit_connector_twilio_pb.js";


### PR DESCRIPTION
`livekit_agent_simulation_pb` is generated and shipped in the tarball but missing from the hand-maintained index, so `Scenario`/`SimulationDispatch`/`SimulationMode` are unreachable (the exports map blocks subpath imports). Needed by livekit/agents-js#2075, which hand-decodes the dispatch protojson until this is released. No name collisions with existing root exports.