### PR TITLE
Remove H.264 baseline (42001f) from default enabled codecs

### DIFF
--- a/codecs/codecs.go
+++ b/codecs/codecs.go
@@ -180,8 +180,6 @@ var (
 		VP9ProfileId1CodecParameters,
 		H264ProfileLevelId42e01fPacketizationMode0CodecParameters,
 		H264ProfileLevelId42e01fPacketizationMode1CodecParameters,
-		H264ProfileLevelId42001fPacketizationMode0CodecParameters,
-		H264ProfileLevelId42001fPacketizationMode1CodecParameters,
 		H264HighProfileCodecParameters,
 		AV1CodecParameters,
 		H265CodecParameters,


### PR DESCRIPTION
It is incompatible with rust-sdk (openh264).