### PR TITLE
rpc: add error_code label to psrpc error_total metric

### DIFF
--- a/.changeset/psrpc-error-code-label.md
+++ b/.changeset/psrpc-error-code-label.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+Add an `error_code` label to the `livekit_psrpc_error_total` metric.

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -15,13 +15,13 @@
 package rpc
 
 import (
+	"maps"
 	"slices"
 	sync "sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
-	"golang.org/x/exp/maps"
 
 	"github.com/livekit/psrpc"
 	"github.com/livekit/psrpc/pkg/middleware"
@@ -78,7 +78,7 @@ func InitPSRPCStats(constLabels prometheus.Labels, opts ...PSRPCMetricsOption) {
 	}
 
 	metricsBase.curryLabels = o.curryLabels
-	curryLabelNames := maps.Keys(o.curryLabels)
+	curryLabelNames := slices.Collect(maps.Keys(o.curryLabels))
 	slices.Sort(curryLabelNames)
 
 	labels := slices.Concat(curryLabelNames, []string{"role", "kind", "service", "method"})

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -15,7 +15,7 @@
 package rpc
 
 import (
-	"sort"
+	"slices"
 	sync "sync"
 	"time"
 
@@ -79,11 +79,12 @@ func InitPSRPCStats(constLabels prometheus.Labels, opts ...PSRPCMetricsOption) {
 
 	metricsBase.curryLabels = o.curryLabels
 	curryLabelNames := maps.Keys(o.curryLabels)
-	sort.Strings(curryLabelNames)
+	slices.Sort(curryLabelNames)
 
-	labels := append(curryLabelNames, "role", "kind", "service", "method")
-	streamLabels := append(curryLabelNames, "role", "service", "method")
-	bytesLabels := append(labels, "direction")
+	labels := slices.Concat(curryLabelNames, []string{"role", "kind", "service", "method"})
+	streamLabels := slices.Concat(curryLabelNames, []string{"role", "service", "method"})
+	errorLabels := slices.Concat(labels, []string{"error_code"})
+	bytesLabels := slices.Concat(labels, []string{"direction"})
 
 	metricsBase.requestTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   livekitNamespace,
@@ -116,7 +117,7 @@ func InitPSRPCStats(constLabels prometheus.Labels, opts ...PSRPCMetricsOption) {
 		Subsystem:   "psrpc",
 		Name:        "error_total",
 		ConstLabels: constLabels,
-	}, labels)
+	}, errorLabels)
 	metricsBase.bytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   livekitNamespace,
 		Subsystem:   "psrpc",
@@ -159,6 +160,13 @@ func CurryMetricLabels(labels prometheus.Labels) {
 	})
 }
 
+func errorCodeLabel(err error) string {
+	if code, ok := psrpc.GetErrorCode(err); ok && code != psrpc.OK {
+		return string(code)
+	}
+	return string(psrpc.Unknown)
+}
+
 var _ middleware.MetricsObserver = PSRPCMetricsObserver{}
 
 type PSRPCMetricsObserver struct{}
@@ -169,7 +177,7 @@ func (o PSRPCMetricsObserver) OnUnaryRequest(role middleware.MetricRole, info ps
 	m.bytesTotal.WithLabelValues(role.String(), "rpc", info.Service, info.Method, "tx").Add(float64(txBytes))
 
 	if err != nil {
-		m.errorTotal.WithLabelValues(role.String(), "rpc", info.Service, info.Method).Inc()
+		m.errorTotal.WithLabelValues(role.String(), "rpc", info.Service, info.Method, errorCodeLabel(err)).Inc()
 	} else {
 		m.requestTime.WithLabelValues(role.String(), "rpc", info.Service, info.Method).Observe(float64(duration.Milliseconds()))
 	}
@@ -181,7 +189,8 @@ func (o PSRPCMetricsObserver) OnMultiRequest(role middleware.MetricRole, info ps
 	m.bytesTotal.WithLabelValues(role.String(), "multirpc", info.Service, info.Method, "tx").Add(float64(txBytes))
 
 	if responseCount == 0 {
-		m.errorTotal.WithLabelValues(role.String(), "multirpc", info.Service, info.Method).Inc()
+		// psrpc's MetricsObserver doesn't surface an error for multi requests
+		m.errorTotal.WithLabelValues(role.String(), "multirpc", info.Service, info.Method, string(psrpc.Unknown)).Inc()
 	} else {
 		m.requestTime.WithLabelValues(role.String(), "multirpc", info.Service, info.Method).Observe(float64(duration.Milliseconds()))
 	}
@@ -192,7 +201,7 @@ func (o PSRPCMetricsObserver) OnStreamSend(role middleware.MetricRole, info psrp
 	m.bytesTotal.WithLabelValues(role.String(), "stream", info.Service, info.Method, "tx").Add(float64(bytes))
 
 	if err != nil {
-		m.errorTotal.WithLabelValues(role.String(), "stream", info.Service, info.Method).Inc()
+		m.errorTotal.WithLabelValues(role.String(), "stream", info.Service, info.Method, errorCodeLabel(err)).Inc()
 	} else {
 		m.streamSendTime.WithLabelValues(role.String(), info.Service, info.Method).Observe(float64(duration.Milliseconds()))
 	}
@@ -203,7 +212,7 @@ func (o PSRPCMetricsObserver) OnStreamRecv(role middleware.MetricRole, info psrp
 	m.bytesTotal.WithLabelValues(role.String(), "stream", info.Service, info.Method, "rx").Add(float64(bytes))
 
 	if err != nil {
-		m.errorTotal.WithLabelValues(role.String(), "stream", info.Service, info.Method).Inc()
+		m.errorTotal.WithLabelValues(role.String(), "stream", info.Service, info.Method, errorCodeLabel(err)).Inc()
 	} else {
 		m.streamReceiveTotal.WithLabelValues(role.String(), info.Service, info.Method).Inc()
 	}

--- a/rpc/metrics_test.go
+++ b/rpc/metrics_test.go
@@ -1,0 +1,53 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/psrpc"
+	"github.com/livekit/psrpc/pkg/middleware"
+)
+
+func TestErrorCodeLabel(t *testing.T) {
+	InitPSRPCStats(prometheus.Labels{})
+
+	info := psrpc.RPCInfo{Service: "svc", Method: "meth"}
+	o := PSRPCMetricsObserver{}
+	o.OnUnaryRequest(middleware.ClientRole, info, 0, psrpc.NewErrorf(psrpc.Unavailable, "x"), 0, 0)
+	o.OnStreamSend(middleware.ClientRole, info, 0, errors.New("bare"), 0)
+	o.OnStreamRecv(middleware.ServerRole, info, context.Canceled, 0)
+	o.OnMultiRequest(middleware.ClientRole, info, 0, 0, 1, 0, 0)
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	var family *dto.MetricFamily
+	for _, f := range families {
+		if f.GetName() == "livekit_psrpc_error_total" {
+			family = f
+			break
+		}
+	}
+	require.NotNil(t, family, "livekit_psrpc_error_total not registered")
+
+	codes := map[string]bool{}
+	for _, m := range family.GetMetric() {
+		found := false
+		for _, l := range m.GetLabel() {
+			if l.GetName() == "error_code" {
+				require.NotEmpty(t, l.GetValue(), "empty error_code on %v", m.GetLabel())
+				codes[l.GetValue()] = true
+				found = true
+			}
+		}
+		require.True(t, found, "missing error_code label on %v", m.GetLabel())
+	}
+
+	require.True(t, codes["unavailable"], "expected unavailable in %v", codes)
+	require.True(t, codes["unknown"], "expected unknown in %v", codes)
+}


### PR DESCRIPTION
## Why

`livekit_psrpc_error_total` counted failed RPCs with only `role, kind, service, method`. When it climbed there was no way to tell *how* the RPCs failed — a burst of `unavailable` (load/affinity), `deadline_exceeded` (timeouts) and `permission_denied` (caller misconfiguration) were indistinguishable, so every spike needed a log dive to triage. psrpc already carries a bounded error taxonomy (`psrpc.ErrorCode`, ~23 constants) that was being thrown away at the metrics boundary.

## What

- `error_code` added as a trailing label on `error_total` only; the other five collectors are untouched.
- Values come from a small `errorCodeLabel` helper wrapping psrpc's existing `GetErrorCode`, so the label domain is exactly psrpc's `ErrorCode` constants — `err.Error()` is never used as a label value, keeping cardinality bounded. `psrpc.OK` (the empty string) and unresolvable errors both collapse to `unknown`.
- Label slices now use `slices.Concat` instead of `append`. This is a correctness prerequisite, not cleanup: `bytesLabels := append(labels, …)` only reallocates today because `maps.Keys` happens to return `len == cap`. Adding a second `append(labels, …)` for `errorLabels` would make both slices write index `len(labels)` of the same backing array whenever `labels` had spare capacity, silently registering one collector with the other's label name.

### Known limitation

Multi requests always report `error_code="unknown"`. psrpc's `middleware.MetricsObserver.OnMultiRequest` has no error parameter and `multiRPCMetricsInterceptor.Recv` drops the error, so the code isn't available. These rows stay separable via the existing `kind="multirpc"`. Surfacing real codes would need an `err` param on that psrpc interface — breaking, though the only implementors anywhere are the two observers in this same file.

Bare `context.Canceled` / `context.DeadlineExceeded` also land in `unknown`, since psrpc doesn't special-case them. Left alone deliberately — if `kind="stream"` turns out to be dominated by `unknown` in practice, that's a two-case pre-check to add later.

## Rollout

Adding a label changes the series identity of `livekit_psrpc_error_total`. Aggregating queries are unaffected — the production alert rules use `sum(rate(livekit_psrpc_error_total{...}))`. Expect a one-scrape discontinuity as old series are replaced by new ones (normal counter-reset handling in `rate()`). Only queries matching the full label set exactly would need updating.

## Test plan

- `go build ./...`, `go vet ./rpc/`, full suite green (30 packages).
- New `rpc/metrics_test.go` drives all four error paths and gathers from the default registry. Deliberately avoids `prometheus/testutil` — its `kylelemons/godebug` dep is absent from `go.sum` and importing it would force a `go.mod` change.
- Mutation-checked the new test: broke `errorCodeLabel` to return `""`, confirmed the test fails, reverted.
- Verified the curried-label path end-to-end against cloud-protocol's real config (`nats_server` curry label), since that's where the `WithLabelValues` arity risk lives: `error_code=deadline_exceeded` landed alongside `nats_server=nats-a`.
- Downstream `go build` in cloud-protocol / cloud-io / cloud-egress / egress. cloud-io, cloud-egress and egress fail, but on a stale `backend-common/observability/gatewayobsimpl` generated reporter and an egress embed pattern — confirmed identical failures with this change stashed. None touch rpc metrics.