### PR TITLE
fix(auth): require exp claim when verifying access tokens

### DIFF
--- a/auth/verifier.go
+++ b/auth/verifier.go
@@ -77,6 +77,11 @@ func (v *APIKeyTokenVerifier) Verify(key interface{}) (*jwt.RegisteredClaims, *C
 		jwt.WithValidMethods(allowedSigningMethods),
 		jwt.WithIssuer(v.apiKey),
 		jwt.WithLeeway(tokenLeeway),
+		// Without this, a token carrying no exp claim passes validation and
+		// never expires. First-party SDKs always set exp, but any hand-rolled
+		// or third-party minter that forgets it silently mints a permanent
+		// credential.
+		jwt.WithExpirationRequired(),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/auth/verifier_test.go
+++ b/auth/verifier_test.go
@@ -49,6 +49,26 @@ func TestVerifier(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("token without exp is rejected", func(t *testing.T) {
+		// hand-rolled JWT with no exp claim (the Go SDK always sets one, so
+		// build it directly to model a third-party minter forgetting exp)
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"iss": apiKey,
+			"nbf": jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+			"video": map[string]interface{}{
+				"roomCreate": true,
+			},
+		})
+		authToken, err := token.SignedString([]byte(secret))
+		require.NoError(t, err)
+
+		v, err := auth.ParseAPIToken(authToken)
+		require.NoError(t, err)
+
+		_, _, err = v.Verify(secret)
+		require.Error(t, err)
+	})
+
 	t.Run("unexpired token is verified", func(t *testing.T) {
 		claim := auth.VideoGrant{RoomCreate: true}
 		at := auth.NewAccessToken(apiKey, secret).


### PR DESCRIPTION
## Problem

`APIKeyTokenVerifier.Verify` parses with `WithValidMethods` / `WithIssuer` / `WithLeeway` but not `WithExpirationRequired`. Under golang-jwt v5, a token carrying **no `exp` claim at all** passes validation and never expires.

First-party SDKs always set `exp` (the Go SDK unconditionally defaults it in `ToJWT`), so this doesn't affect well-behaved minters — but any hand-rolled or third-party minter that forgets `exp` silently mints a permanent credential, and the server accepts it without complaint.

## Fix

Add `jwt.WithExpirationRequired()` to the parse options. One line; tokens with a valid `exp` are unaffected.

## Tests

Added `token without exp is rejected` to `TestVerifier`, using a hand-rolled `jwt.MapClaims` token (the Go SDK always sets `exp`, so the case has to be built directly). `go test ./auth/` passes.

Made with Cursor

Made with [Cursor](https://cursor.com)