### PR TITLE
Fall back to query-value redaction for non-rtmp stream urls

### DIFF
--- a/egress/redact_test.go
+++ b/egress/redact_test.go
@@ -110,6 +110,7 @@ func TestRedactStreamOutput(t *testing.T) {
 			"mux://8e0b1b9c-50a2-d893-ec0a-102056d112ae",
 			"twitch://live_12345678_abcdefghijklmnop",
 			"srt://foo.bar.com:9999",
+			"srt://foo.bar.com:9999?streamid=124939da-5244&passphrase=WnxknzJTUbwYl9SpdqAudX",
 		},
 	}
 
@@ -118,6 +119,7 @@ func TestRedactStreamOutput(t *testing.T) {
 	require.Equal(t, "mux://{8e0...2ae}", so.Urls[1])
 	require.Equal(t, "twitch://{liv...nop}", so.Urls[2])
 	require.Equal(t, "srt://foo.bar.com:9999", so.Urls[3])
+	require.Equal(t, "srt://foo.bar.com:9999?streamid={...}&passphrase={...}", so.Urls[4])
 }
 
 func TestRedactEncodedOutputs(t *testing.T) {
@@ -183,6 +185,6 @@ func TestRedactDirectOutput(t *testing.T) {
 
 	RedactDirectOutputs(websocket)
 	require.Equal(t,
-		"wss://foo.bar.com/audio?callId={1...5}&token={7df...2b9}",
+		"wss://foo.bar.com/audio?callId={...}&token={...}",
 		websocket.Output.(*livekit.TrackEgressRequest_WebsocketUrl).WebsocketUrl)
 }

--- a/utils/redact.go
+++ b/utils/redact.go
@@ -33,6 +33,9 @@ func RedactStreamKey(url string) (string, bool) {
 
 	match := rtmpRegexp.FindStringSubmatch(url)
 	if len(match) != 6 {
+		if redacted := RedactUrlQueryValues(url); redacted != url {
+			return redacted, true
+		}
 		return url, false
 	}
 
@@ -40,7 +43,7 @@ func RedactStreamKey(url string) (string, bool) {
 	return strings.Join(match[1:], ""), true
 }
 
-// RedactUrlQueryValues redacts every query parameter value in rawUrl, keeping parameter names intact.
+// RedactUrlQueryValues fully redacts every query parameter value in rawUrl, keeping parameter names intact.
 func RedactUrlQueryValues(rawUrl string) string {
 	base, query, found := strings.Cut(rawUrl, "?")
 	if !found || query == "" {
@@ -50,7 +53,7 @@ func RedactUrlQueryValues(rawUrl string) string {
 	params := strings.Split(query, "&")
 	for i, p := range params {
 		if k, v, ok := strings.Cut(p, "="); ok && v != "" {
-			params[i] = k + "=" + RedactIdentifier(v)
+			params[i] = k + "={...}"
 		}
 	}
 	return base + "?" + strings.Join(params, "&")


### PR DESCRIPTION
Follow-up to #1713. Urls that don't match the rtmp or mux/twitch patterns now fall back to query-value redaction (e.g. srt urls with streamid/passphrase params), and query values are masked as `{...}` instead of keeping first/last characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)