### PR TITLE
ci: fix the Go build cache never being hit

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -26,18 +26,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/.cache
-          key: livekit-protocol
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "go.mod"
+          # setup-go's own cache restores on an exact key only, so any go.sum
+          # change is a full cold build. Restored below instead.
+          cache: false
+
+      # The run_id suffix never pre-exists, so a push always writes a fresh
+      # entry rather than one frozen at the go.sum that first created it.
+      - name: Restore Go caches
+        id: go-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('go.sum') }}-
+            go-${{ runner.os }}-
 
       - name: Set up gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@9eae5abc81d6d08f73268741ef4a8b97f29b60d8 # v2.4.1
@@ -54,3 +64,14 @@ jobs:
         run: |
           set -euo pipefail
           MallocNanoZone=0 go test -race -json -v ./... 2>&1 | gotestfmt
+
+      # Only main writes. Pull requests read main's entry, which keeps ~1 GB
+      # per PR run out of the repo's 10 GB cache budget.
+      - name: Save Go caches
+        if: github.event_name == 'push'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ steps.go-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
The `Test` job compiles the module from scratch on every run, because neither of the two caches configured here has ever produced a hit.

**The `actions/cache` step used a constant key.** `key: livekit-protocol` never changes, and `actions/cache` does not re-save on a hit, so the entry stayed frozen at whatever it held when first written. The cache API reports it as **364 MB, created 2025-09-08**, still being restored today — and because every run reads it, its last-accessed time keeps refreshing, so it never ages out either. Nothing in it could match: it cached all of `~/.cache`, whose `go-build` entries are keyed by compiler build ID, so a newer toolchain misses every one. It cost time on every run and left a `GOCACHE` full of dead entries that `setup-go` then re-uploaded.

**setup-go's built-in cache cannot close the gap.** Its key is `setup-go-{os}-{arch}-{linuxver}go-{version}-{go.sum hash}`, and it calls `restoreCache` with no restore keys — a match is exact or nothing, and upstream has declined to add prefix fallback ([actions/setup-go#404](https://github.com/actions/setup-go/issues/404)). So any dependency bump rebuilds everything rather than just the part that changed, and a Go point release rotates the key out from under every open PR at once.

**The repo is over its cache budget.** It currently holds **12.24 GB** against a 10 GB limit, so entries are being evicted continuously. Five `refs/pull/N/merge` entries of 585–798 MB each are setup-go saves from pull request runs, in a scope no other run can read.

## What this changes

- Drops the dead `actions/cache` step.
- Sets `cache: false` on setup-go and restores via `actions/cache/restore`, keyed on the `go.sum` hash with a prefix fallback, so a dependency change reuses the entries that are still valid.
- Suffixes the key with `run_id` so it never matches on write. A push therefore always stores a fresh entry, rather than one pinned to the `go.sum` that first created it.
- Limits saving to pushes. Pull requests read main's entry and write nothing, which keeps roughly a gigabyte per PR run out of the repo's 10 GB budget.

Narrowing the paths to `~/.cache/go-build` and `~/go/pkg/mod` drops `~/go/bin`. Binaries installed there are re-`go install`ed on every run regardless, and the build cache covers most of that cost.

## Follow-up, not in this PR

The stale entries need clearing to get back under budget, including the 364 MB `livekit-protocol` one this PR stops writing to.
