### PR TITLE
redis: honour dial/read/write timeouts in all modes, not just Sentinel

### DIFF
--- a/.changeset/redis-timeouts-all-modes.md
+++ b/.changeset/redis-timeouts-all-modes.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+Honour `dial_timeout`, `read_timeout` and `write_timeout` for single-address and cluster Redis, not just Sentinel. They were previously accepted by `RedisConfig` but only ever read in the Sentinel branch, so setting them on any other deployment silently did nothing.

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -137,6 +137,9 @@ func GetRedisClient(conf *RedisConfig) (redis.UniversalClient, error) {
 			DB:            conf.DB,
 			TLSConfig:     tlsConfig,
 			MaxRedirects:  conf.GetMaxRedirects(),
+			DialTimeout:   time.Duration(conf.DialTimeout) * time.Millisecond,
+			ReadTimeout:   time.Duration(conf.ReadTimeout) * time.Millisecond,
+			WriteTimeout:  time.Duration(conf.WriteTimeout) * time.Millisecond,
 			PoolTimeout:   conf.PoolTimeout,
 			PoolSize:      conf.PoolSize,
 			IsClusterMode: true,
@@ -144,13 +147,16 @@ func GetRedisClient(conf *RedisConfig) (redis.UniversalClient, error) {
 	} else {
 		logger.Infow("connecting to redis", "simple", true, "addr", conf.Address)
 		rcOptions = &redis.UniversalOptions{
-			Addrs:       []string{conf.Address},
-			Username:    conf.Username,
-			Password:    conf.Password,
-			DB:          conf.DB,
-			TLSConfig:   tlsConfig,
-			PoolTimeout: conf.PoolTimeout,
-			PoolSize:    conf.PoolSize,
+			Addrs:        []string{conf.Address},
+			Username:     conf.Username,
+			Password:     conf.Password,
+			DB:           conf.DB,
+			TLSConfig:    tlsConfig,
+			DialTimeout:  time.Duration(conf.DialTimeout) * time.Millisecond,
+			ReadTimeout:  time.Duration(conf.ReadTimeout) * time.Millisecond,
+			WriteTimeout: time.Duration(conf.WriteTimeout) * time.Millisecond,
+			PoolTimeout:  conf.PoolTimeout,
+			PoolSize:     conf.PoolSize,
 		}
 	}
 	rc = redis.NewUniversalClient(rcOptions)


### PR DESCRIPTION
`RedisConfig` exposes `dial_timeout`, `read_timeout` and `write_timeout`, but `GetRedisClient` only reads them in the Sentinel branch. A single-address or cluster deployment can set them and they are silently ignored — nothing errors and nothing warns.

This passes them through in all three branches. Sentinel keeps its existing 2000/200/200 defaults; the other two leave an unset value at zero so go-redis applies its own defaults, so a config that does not set them behaves exactly as before.

### How it turned up

Debugging a self-hosted SFU where `RedisRouter.statsWorker` stalled ~31s and logged `status update delayed, possible deadlock`, with the goroutine parked in go-redis `ConnPool.queuedNewConn`.

That stall is not reachable from config today. `PoolTimeout` bounds only `waitTurn`; `pool.go` notes that `queuedNewConn` deliberately applies no timeout of its own because `dialConn` applies `DialTimeout` per attempt — and `dialConn` retries `DialerRetries` (default 5) times. With `DialTimeout` never passed through on the simple path, there is no way to bound that from YAML.

The knock-on effect is user visible: while `statsWorker` is stalled the node's `Stats.UpdatedAt` goes stale, and `LivekitServer.healthCheck` returns 406 once it is more than 4s old. Anything using `/` as a health probe sees the node as unhealthy.

### Notes

- Behaviour is unchanged for any config that does not set these fields.
- Sentinel is untouched.
- Includes a changeset (patch).
- `gofmt`, `go build ./redis/...` and `go vet ./redis/...` all clean.