### PR TITLE
ci: set explicit GITHUB_TOKEN permissions on generate and test

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read # Lint and test only read the checkout
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -19,6 +19,9 @@ on:
   push:
     branches-ignore: [main]
 
+permissions:
+  contents: write # Required to commit the regenerated output
+
 jobs:
   generate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #1733. CodeQL flagged the equivalent workflow in [psrpc#124](https://github.com/livekit/psrpc/pull/124) for relying on the default `GITHUB_TOKEN` permissions (`actions/missing-workflow-permissions`). These two workflows predate the check so nothing flagged them, but they carry the same exposure. `release.yaml` and `slack-notifier.yaml` already scope theirs.

| workflow | permission | why |
|---|---|---|
| `generate.yaml` | `contents: write` | `add-and-commit` pushes the regenerated output |
| `buildtest.yaml` | `contents: read` | lint and test only read the checkout |

Note `generate.yaml` deliberately does **not** take CodeQL's suggested `contents: read` starting point — that would break the commit step.

`buildtest.yaml` needs nothing beyond `contents: read`: the cache restore/save steps and `golangci-lint-action` require no additional scopes (`pull-requests: read` is only needed for `only-new-issues`, which isn't set).

After this, every workflow in the repo has an explicit block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)