### PR TITLE
Add realtime billing reporters

### DIFF
--- a/observability/gatewayobs/gen_reporter.go
+++ b/observability/gatewayobs/gen_reporter.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const Version_F2D2A50 = true
+const Version_3V1GTG0 = true
 
 type KeyResolver interface {
 	Resolve(string)
@@ -118,6 +118,7 @@ type modelReporter interface {
 	ReportRealtimeOutputAudioTokens(v uint64)
 	ReportRealtimeCachedTextTokens(v uint64)
 	ReportRealtimeCachedAudioTokens(v uint64)
+	ReportRealtimeCachedImageTokens(v uint64)
 	ReportRealtimeTextInputMessages(v uint64)
 	ReportSttDuration(v uint32)
 	ReportTtsChars(v uint32)

--- a/observability/gatewayobs/gen_reporter.go
+++ b/observability/gatewayobs/gen_reporter.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const Version_J1BFFVO = true
+const Version_F2D2A50 = true
 
 type KeyResolver interface {
 	Resolve(string)
@@ -118,6 +118,7 @@ type modelReporter interface {
 	ReportRealtimeOutputAudioTokens(v uint64)
 	ReportRealtimeCachedTextTokens(v uint64)
 	ReportRealtimeCachedAudioTokens(v uint64)
+	ReportRealtimeTextInputMessages(v uint64)
 	ReportSttDuration(v uint32)
 	ReportTtsChars(v uint32)
 	ReportBargeInRequests(v uint64)

--- a/observability/gatewayobs/gen_reporter_noop.go
+++ b/observability/gatewayobs/gen_reporter_noop.go
@@ -173,6 +173,7 @@ func (r *noopModelReporter) ReportRealtimeOutputTextTokens(v uint64)            
 func (r *noopModelReporter) ReportRealtimeOutputAudioTokens(v uint64)             {}
 func (r *noopModelReporter) ReportRealtimeCachedTextTokens(v uint64)              {}
 func (r *noopModelReporter) ReportRealtimeCachedAudioTokens(v uint64)             {}
+func (r *noopModelReporter) ReportRealtimeTextInputMessages(v uint64)             {}
 func (r *noopModelReporter) ReportSttDuration(v uint32)                           {}
 func (r *noopModelReporter) ReportTtsChars(v uint32)                              {}
 func (r *noopModelReporter) ReportBargeInRequests(v uint64)                       {}
@@ -202,6 +203,7 @@ func (t *noopModelTx) ReportRealtimeOutputTextTokens(v uint64)              {}
 func (t *noopModelTx) ReportRealtimeOutputAudioTokens(v uint64)             {}
 func (t *noopModelTx) ReportRealtimeCachedTextTokens(v uint64)              {}
 func (t *noopModelTx) ReportRealtimeCachedAudioTokens(v uint64)             {}
+func (t *noopModelTx) ReportRealtimeTextInputMessages(v uint64)             {}
 func (t *noopModelTx) ReportSttDuration(v uint32)                           {}
 func (t *noopModelTx) ReportTtsChars(v uint32)                              {}
 func (t *noopModelTx) ReportBargeInRequests(v uint64)                       {}

--- a/observability/gatewayobs/gen_reporter_noop.go
+++ b/observability/gatewayobs/gen_reporter_noop.go
@@ -173,6 +173,7 @@ func (r *noopModelReporter) ReportRealtimeOutputTextTokens(v uint64)            
 func (r *noopModelReporter) ReportRealtimeOutputAudioTokens(v uint64)             {}
 func (r *noopModelReporter) ReportRealtimeCachedTextTokens(v uint64)              {}
 func (r *noopModelReporter) ReportRealtimeCachedAudioTokens(v uint64)             {}
+func (r *noopModelReporter) ReportRealtimeCachedImageTokens(v uint64)             {}
 func (r *noopModelReporter) ReportRealtimeTextInputMessages(v uint64)             {}
 func (r *noopModelReporter) ReportSttDuration(v uint32)                           {}
 func (r *noopModelReporter) ReportTtsChars(v uint32)                              {}
@@ -203,6 +204,7 @@ func (t *noopModelTx) ReportRealtimeOutputTextTokens(v uint64)              {}
 func (t *noopModelTx) ReportRealtimeOutputAudioTokens(v uint64)             {}
 func (t *noopModelTx) ReportRealtimeCachedTextTokens(v uint64)              {}
 func (t *noopModelTx) ReportRealtimeCachedAudioTokens(v uint64)             {}
+func (t *noopModelTx) ReportRealtimeCachedImageTokens(v uint64)             {}
 func (t *noopModelTx) ReportRealtimeTextInputMessages(v uint64)             {}
 func (t *noopModelTx) ReportSttDuration(v uint32)                           {}
 func (t *noopModelTx) ReportTtsChars(v uint32)                              {}


### PR DESCRIPTION
## Summary
- expose generated reporters for billable realtime text-input messages
- expose generated reporters for discounted cached-image tokens already present in the merged observability schema
- keep both dimensions distinct from operational request counts and gross image input

## Test plan
- [x] `GOWORK=off go test ./observability/gatewayobs`
- [x] `git diff --check origin/main...HEAD`