### PR TITLE
auth: add AgentGrant.DispatchAdmin

### DIFF
--- a/.changeset/agent-dispatch-admin-grant.md
+++ b/.changeset/agent-dispatch-admin-grant.md
@@ -1,0 +1,6 @@
+---
+"github.com/livekit/protocol": patch
+"@livekit/protocol": patch
+---
+
+Add `AgentGrant.DispatchAdmin`

--- a/auth/grants.go
+++ b/auth/grants.go
@@ -583,6 +583,8 @@ type AgentGrant struct {
 	SimulationAdmin bool `json:"simulationAdmin,omitempty"`
 	// DatabaseAdmin grants access to a project's agent databases (AgentDB).
 	DatabaseAdmin bool `json:"databaseAdmin,omitempty"`
+	// DispatchAdmin grants access to manage a project's agent dispatch queue.
+	DispatchAdmin bool `json:"dispatchAdmin,omitempty"`
 }
 
 func (s *AgentGrant) Clone() *AgentGrant {
@@ -603,6 +605,7 @@ func (s *AgentGrant) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddBool("Admin", s.Admin)
 	e.AddBool("SimulationAdmin", s.SimulationAdmin)
 	e.AddBool("DatabaseAdmin", s.DatabaseAdmin)
+	e.AddBool("DispatchAdmin", s.DispatchAdmin)
 	return nil
 }
 

--- a/auth/grants_test.go
+++ b/auth/grants_test.go
@@ -120,7 +120,8 @@ func TestGrants(t *testing.T) {
 
 	t.Run("clone with Agent", func(t *testing.T) {
 		agent := &AgentGrant{
-			Admin: true,
+			Admin:         true,
+			DispatchAdmin: true,
 		}
 		grants := &ClaimGrants{
 			Identity: "identity",


### PR DESCRIPTION
Adds `AgentGrant.DispatchAdmin`, granting access to manage a project's agent dispatch
queue.

The service it authorizes is defined in cloud-protocol; only the grant type is shared, so
only the grant lands here.
