### PR TITLE
utils: add Promise.Then and lazily init the done channel

### DIFF
--- a/.changeset/promise-then.md
+++ b/.changeset/promise-then.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+`utils.Promise` gains `Then(func(T, error))`, registering a callback to run when the promise resolves. Callbacks run on the goroutine that calls `Resolve`, in registration order; registering on an already-resolved promise runs the callback inline on the caller. `NewPromise` no longer allocates the done channel up front — `Done()` already created it lazily.

--- a/utils/promise.go
+++ b/utils/promise.go
@@ -14,14 +14,13 @@ func init() {
 type Promise[T any] struct {
 	mu     sync.Mutex
 	done   chan struct{}
+	thens  []func(T, error)
 	Result T
 	Err    error
 }
 
 func NewPromise[T any]() *Promise[T] {
-	return &Promise[T]{
-		done: make(chan struct{}),
-	}
+	return &Promise[T]{}
 }
 
 func GoPromise[T any](f func() (T, error)) *Promise[T] {
@@ -40,9 +39,9 @@ func NewResolvedPromise[T any](result T, err error) *Promise[T] {
 
 func (p *Promise[T]) Resolve(result T, err error) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	if p.done == closedPromiseChan {
+		p.mu.Unlock()
 		return
 	}
 
@@ -53,6 +52,31 @@ func (p *Promise[T]) Resolve(result T, err error) {
 		close(p.done)
 	}
 	p.done = closedPromiseChan
+
+	thens := p.thens
+	p.thens = nil
+	p.mu.Unlock()
+
+	// invoked unlocked so a callback can re-enter the promise
+	for _, f := range thens {
+		f(result, err)
+	}
+}
+
+// Then registers f to run when p resolves, on the goroutine that calls Resolve. If p is
+// already resolved, f runs inline on the calling goroutine.
+func (p *Promise[T]) Then(f func(T, error)) {
+	p.mu.Lock()
+
+	if p.done == closedPromiseChan {
+		result, err := p.Result, p.Err
+		p.mu.Unlock()
+		f(result, err)
+		return
+	}
+
+	p.thens = append(p.thens, f)
+	p.mu.Unlock()
 }
 
 func (p *Promise[T]) Done() <-chan struct{} {

--- a/utils/promise_test.go
+++ b/utils/promise_test.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -38,5 +40,124 @@ func TestPromise(t *testing.T) {
 
 		require.False(t, p.Result)
 		require.Error(t, p.Err)
+	})
+}
+
+func TestPromiseThen(t *testing.T) {
+	t.Run("callback runs on the resolving goroutine", func(t *testing.T) {
+		p := NewPromise[int]()
+
+		var (
+			gotResult int
+			gotErr    error
+			called    bool
+		)
+		p.Then(func(result int, err error) {
+			gotResult, gotErr, called = result, err, true
+		})
+		require.False(t, called, "callback should not run before resolution")
+
+		expErr := errors.New("fail")
+		var calledBeforeResolveReturned bool
+		resolved := make(chan struct{})
+		go func() {
+			defer close(resolved)
+			p.Resolve(7, expErr)
+			calledBeforeResolveReturned = called
+		}()
+
+		<-resolved
+		require.True(t, calledBeforeResolveReturned, "callback should have run before Resolve returned")
+		require.Equal(t, 7, gotResult)
+		require.Equal(t, expErr, gotErr)
+	})
+
+	t.Run("callback registered after resolution runs inline", func(t *testing.T) {
+		p := NewPromise[int]()
+		p.Resolve(7, nil)
+
+		var called bool
+		p.Then(func(result int, err error) {
+			called = true
+			require.Equal(t, 7, result)
+			require.NoError(t, err)
+		})
+		require.True(t, called, "callback should run before Then returned")
+	})
+
+	t.Run("callbacks run in registration order", func(t *testing.T) {
+		p := NewPromise[int]()
+
+		var order []int
+		for i := range 3 {
+			p.Then(func(int, error) { order = append(order, i) })
+		}
+		p.Resolve(0, nil)
+
+		require.Equal(t, []int{0, 1, 2}, order)
+	})
+
+	t.Run("callbacks run once when resolved twice", func(t *testing.T) {
+		p := NewPromise[int]()
+
+		var calls int
+		p.Then(func(int, error) { calls++ })
+
+		p.Resolve(1, nil)
+		p.Resolve(2, nil)
+
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("zero value and resolved promise accept callbacks", func(t *testing.T) {
+		var zero Promise[int]
+		var zeroCalled bool
+		zero.Then(func(result int, err error) { zeroCalled = true })
+		require.False(t, zeroCalled)
+		zero.Resolve(7, nil)
+		require.True(t, zeroCalled)
+
+		var resolvedCalled bool
+		NewResolvedPromise(7, nil).Then(func(result int, err error) {
+			resolvedCalled = true
+			require.Equal(t, 7, result)
+		})
+		require.True(t, resolvedCalled)
+	})
+
+	t.Run("callback can re-enter the promise", func(t *testing.T) {
+		p := NewPromise[int]()
+
+		var (
+			resolvedDuringCallback bool
+			awaitResult            int
+			awaitErr               error
+			nested                 bool
+		)
+		p.Then(func(int, error) {
+			resolvedDuringCallback = p.Resolved()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			awaitResult, awaitErr = AwaitPromise(ctx, p)
+
+			p.Then(func(int, error) { nested = true })
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			p.Resolve(7, nil)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "re-entrant callback deadlocked")
+		}
+		require.True(t, resolvedDuringCallback)
+		require.Equal(t, 7, awaitResult)
+		require.NoError(t, awaitErr)
+		require.True(t, nested, "callback registered during dispatch should run inline")
 	})
 }


### PR DESCRIPTION
## Then

`utils.Promise` only supported *pull*-style consumption — block on `Done()` or `AwaitPromise`. Reacting to a resolution meant parking a goroutine on the channel.

`Then(func(T, error))` adds *push*-style consumption:

```go
p := GoPromise(fetch)
p.Then(logResult)
p.Then(updateCache)
```

Semantics:

- Callbacks run **on the goroutine that calls `Resolve`**, in registration order. No dispatch goroutine, no worker pool — so `Resolve` does not return until every callback has. A slow callback delays the resolver.
- Registering on an **already-resolved** promise runs the callback inline on the registering goroutine, so a callback always runs exactly once and is never silently dropped on a `Then`/`Resolve` race.
- Callbacks are invoked **outside the mutex**, so one may re-enter the promise (`Resolved()`, `Then()`, `AwaitPromise()`) without deadlocking. `Resolve` therefore unlocks explicitly rather than via `defer`.
- `done` closes *before* callbacks run, so waiters wake immediately instead of queueing behind callback work, and a callback can await its own promise. Trade-off: `Done()` firing does not imply callbacks have finished.
- A panicking callback propagates to the resolver rather than being recovered — that's a caller bug worth surfacing.

## Lazy done channel

`NewPromise` no longer allocates the done channel up front; `Done()` already created it lazily, and `Resolve` already handled the nil case. A promise nobody waits on and nobody registers on now allocates nothing, and `NewPromise[T]()` and the zero value `var p Promise[T]` behave identically. The new `thens` slice keeps that property — nil until the first `Then`.

## Testing

Six new subtests in `TestPromiseThen`, all passing under `-race`, plus the full `./utils` suite.

I mutation-tested the central assertion: switching the dispatch loop to `go func(){ ... }()` makes the resolving-goroutine, ordering, and exactly-once subtests fail, so they pin real behavior rather than passing vacuously.

Note: `go vet ./utils/` reports `possible misuse of unsafe.Pointer` at `utils/lock_tracker.go:145`. That is pre-existing on `main` and untouched here.