### PR TITLE
add RoomEndReason to room-ended telemetry

### DIFF
--- a/.changeset/room-end-reason.md
+++ b/.changeset/room-end-reason.md
@@ -1,0 +1,6 @@
+---
+"github.com/livekit/protocol": minor
+"@livekit/protocol": minor
+---
+
+add `RoomEndReason` enum and report it on room-ended telemetry: `AnalyticsEvent.room_end_reason` and `WebhookEvent.room_end_reason` now say why a room ended (`ROOM_END_API_DELETE`, `ROOM_END_IDLE_TIMEOUT`, `ROOM_END_SERVER_SHUTDOWN`, `ROOM_END_SUPERSEDED`, `ROOM_END_OPEN_FAILED`), so room-end volume can be broken down by cause the way participant disconnects already are

--- a/livekit/livekit_analytics.pb.go
+++ b/livekit/livekit_analytics.pb.go
@@ -897,6 +897,7 @@ type AnalyticsEvent struct {
 	Report                    *ReportInfo            `protobuf:"bytes,33,opt,name=report,proto3" json:"report,omitempty"`
 	ApiCall                   *APICallInfo           `protobuf:"bytes,34,opt,name=api_call,json=apiCall,proto3" json:"api_call,omitempty"`
 	Webhook                   *WebhookInfo           `protobuf:"bytes,35,opt,name=webhook,proto3" json:"webhook,omitempty"`
+	RoomEndReason             RoomEndReason          `protobuf:"varint,37,opt,name=room_end_reason,json=roomEndReason,proto3,enum=livekit.RoomEndReason" json:"room_end_reason,omitempty"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -1167,6 +1168,13 @@ func (x *AnalyticsEvent) GetWebhook() *WebhookInfo {
 		return x.Webhook
 	}
 	return nil
+}
+
+func (x *AnalyticsEvent) GetRoomEndReason() RoomEndReason {
+	if x != nil {
+		return x.RoomEndReason
+	}
+	return RoomEndReason_ROOM_END_UNKNOWN
 }
 
 type AnalyticsEvents struct {
@@ -2315,7 +2323,7 @@ const file_livekit_analytics_proto_rawDesc = "" +
 	"\n" +
 	"\b_countryB\n" +
 	"\n" +
-	"\b_isp_asn\"\x98\r\n" +
+	"\b_isp_asn\"\xd8\r\n" +
 	"\x0eAnalyticsEvent\x12\x0e\n" +
 	"\x02id\x18\x19 \x01(\tR\x02id\x12/\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1b.livekit.AnalyticsEventTypeR\x04type\x128\n" +
@@ -2358,7 +2366,8 @@ const file_livekit_analytics_proto_rawDesc = "" +
 	"\fsip_transfer\x18$ \x01(\v2\x18.livekit.SIPTransferInfoR\vsipTransfer\x12+\n" +
 	"\x06report\x18! \x01(\v2\x13.livekit.ReportInfoR\x06report\x12/\n" +
 	"\bapi_call\x18\" \x01(\v2\x14.livekit.APICallInfoR\aapiCall\x12.\n" +
-	"\awebhook\x18# \x01(\v2\x14.livekit.WebhookInfoR\awebhook\"B\n" +
+	"\awebhook\x18# \x01(\v2\x14.livekit.WebhookInfoR\awebhook\x12>\n" +
+	"\x0froom_end_reason\x18% \x01(\x0e2\x16.livekit.RoomEndReasonR\rroomEndReason\"B\n" +
 	"\x0fAnalyticsEvents\x12/\n" +
 	"\x06events\x18\x01 \x03(\v2\x17.livekit.AnalyticsEventR\x06events\"\xc9\x01\n" +
 	"\x18AnalyticsRoomParticipant\x12\x0e\n" +
@@ -2582,17 +2591,18 @@ var file_livekit_analytics_proto_goTypes = []any{
 	(*SIPOutboundTrunkInfo)(nil),       // 32: livekit.SIPOutboundTrunkInfo
 	(*SIPDispatchRuleInfo)(nil),        // 33: livekit.SIPDispatchRuleInfo
 	(*SIPTransferInfo)(nil),            // 34: livekit.SIPTransferInfo
-	(ParticipantInfo_State)(0),         // 35: livekit.ParticipantInfo.State
-	(*CreateRoomRequest)(nil),          // 36: livekit.CreateRoomRequest
-	(*ListRoomsRequest)(nil),           // 37: livekit.ListRoomsRequest
-	(*DeleteRoomRequest)(nil),          // 38: livekit.DeleteRoomRequest
-	(*ListParticipantsRequest)(nil),    // 39: livekit.ListParticipantsRequest
-	(*RoomParticipantIdentity)(nil),    // 40: livekit.RoomParticipantIdentity
-	(*MuteRoomTrackRequest)(nil),       // 41: livekit.MuteRoomTrackRequest
-	(*UpdateParticipantRequest)(nil),   // 42: livekit.UpdateParticipantRequest
-	(*UpdateSubscriptionsRequest)(nil), // 43: livekit.UpdateSubscriptionsRequest
-	(*SendDataRequest)(nil),            // 44: livekit.SendDataRequest
-	(*UpdateRoomMetadataRequest)(nil),  // 45: livekit.UpdateRoomMetadataRequest
+	(RoomEndReason)(0),                 // 35: livekit.RoomEndReason
+	(ParticipantInfo_State)(0),         // 36: livekit.ParticipantInfo.State
+	(*CreateRoomRequest)(nil),          // 37: livekit.CreateRoomRequest
+	(*ListRoomsRequest)(nil),           // 38: livekit.ListRoomsRequest
+	(*DeleteRoomRequest)(nil),          // 39: livekit.DeleteRoomRequest
+	(*ListParticipantsRequest)(nil),    // 40: livekit.ListParticipantsRequest
+	(*RoomParticipantIdentity)(nil),    // 41: livekit.RoomParticipantIdentity
+	(*MuteRoomTrackRequest)(nil),       // 42: livekit.MuteRoomTrackRequest
+	(*UpdateParticipantRequest)(nil),   // 43: livekit.UpdateParticipantRequest
+	(*UpdateSubscriptionsRequest)(nil), // 44: livekit.UpdateSubscriptionsRequest
+	(*SendDataRequest)(nil),            // 45: livekit.SendDataRequest
+	(*UpdateRoomMetadataRequest)(nil),  // 46: livekit.UpdateRoomMetadataRequest
 }
 var file_livekit_analytics_proto_depIdxs = []int32{
 	3,  // 0: livekit.AnalyticsStream.video_layers:type_name -> livekit.AnalyticsVideoLayer
@@ -2623,39 +2633,40 @@ var file_livekit_analytics_proto_depIdxs = []int32{
 	13, // 25: livekit.AnalyticsEvent.report:type_name -> livekit.ReportInfo
 	17, // 26: livekit.AnalyticsEvent.api_call:type_name -> livekit.APICallInfo
 	18, // 27: livekit.AnalyticsEvent.webhook:type_name -> livekit.WebhookInfo
-	8,  // 28: livekit.AnalyticsEvents.events:type_name -> livekit.AnalyticsEvent
-	35, // 29: livekit.AnalyticsRoomParticipant.state:type_name -> livekit.ParticipantInfo.State
-	20, // 30: livekit.AnalyticsRoomParticipant.joined_at:type_name -> google.protobuf.Timestamp
-	20, // 31: livekit.AnalyticsRoom.created_at:type_name -> google.protobuf.Timestamp
-	10, // 32: livekit.AnalyticsRoom.participants:type_name -> livekit.AnalyticsRoomParticipant
-	20, // 33: livekit.AnalyticsNodeRooms.timestamp:type_name -> google.protobuf.Timestamp
-	11, // 34: livekit.AnalyticsNodeRooms.rooms:type_name -> livekit.AnalyticsRoom
-	15, // 35: livekit.ReportInfo.feature_usage:type_name -> livekit.FeatureUsageInfo
-	20, // 36: livekit.TimeRange.started_at:type_name -> google.protobuf.Timestamp
-	20, // 37: livekit.TimeRange.ended_at:type_name -> google.protobuf.Timestamp
-	2,  // 38: livekit.FeatureUsageInfo.feature:type_name -> livekit.FeatureUsageInfo.Feature
-	14, // 39: livekit.FeatureUsageInfo.time_ranges:type_name -> livekit.TimeRange
-	19, // 40: livekit.FeatureUsageInfo.feature_info:type_name -> livekit.FeatureUsageInfo.FeatureInfoEntry
-	36, // 41: livekit.APICallRequest.create_room_request:type_name -> livekit.CreateRoomRequest
-	37, // 42: livekit.APICallRequest.list_rooms_request:type_name -> livekit.ListRoomsRequest
-	38, // 43: livekit.APICallRequest.delete_room_request:type_name -> livekit.DeleteRoomRequest
-	39, // 44: livekit.APICallRequest.list_participants_request:type_name -> livekit.ListParticipantsRequest
-	40, // 45: livekit.APICallRequest.room_participant_identity:type_name -> livekit.RoomParticipantIdentity
-	41, // 46: livekit.APICallRequest.mute_room_track_request:type_name -> livekit.MuteRoomTrackRequest
-	42, // 47: livekit.APICallRequest.update_participant_request:type_name -> livekit.UpdateParticipantRequest
-	43, // 48: livekit.APICallRequest.update_subscriptions_request:type_name -> livekit.UpdateSubscriptionsRequest
-	44, // 49: livekit.APICallRequest.send_data_request:type_name -> livekit.SendDataRequest
-	45, // 50: livekit.APICallRequest.update_room_metadata_request:type_name -> livekit.UpdateRoomMetadataRequest
-	16, // 51: livekit.APICallInfo.request:type_name -> livekit.APICallRequest
-	20, // 52: livekit.APICallInfo.started_at:type_name -> google.protobuf.Timestamp
-	20, // 53: livekit.WebhookInfo.created_at:type_name -> google.protobuf.Timestamp
-	20, // 54: livekit.WebhookInfo.queued_at:type_name -> google.protobuf.Timestamp
-	20, // 55: livekit.WebhookInfo.sent_at:type_name -> google.protobuf.Timestamp
-	56, // [56:56] is the sub-list for method output_type
-	56, // [56:56] is the sub-list for method input_type
-	56, // [56:56] is the sub-list for extension type_name
-	56, // [56:56] is the sub-list for extension extendee
-	0,  // [0:56] is the sub-list for field type_name
+	35, // 28: livekit.AnalyticsEvent.room_end_reason:type_name -> livekit.RoomEndReason
+	8,  // 29: livekit.AnalyticsEvents.events:type_name -> livekit.AnalyticsEvent
+	36, // 30: livekit.AnalyticsRoomParticipant.state:type_name -> livekit.ParticipantInfo.State
+	20, // 31: livekit.AnalyticsRoomParticipant.joined_at:type_name -> google.protobuf.Timestamp
+	20, // 32: livekit.AnalyticsRoom.created_at:type_name -> google.protobuf.Timestamp
+	10, // 33: livekit.AnalyticsRoom.participants:type_name -> livekit.AnalyticsRoomParticipant
+	20, // 34: livekit.AnalyticsNodeRooms.timestamp:type_name -> google.protobuf.Timestamp
+	11, // 35: livekit.AnalyticsNodeRooms.rooms:type_name -> livekit.AnalyticsRoom
+	15, // 36: livekit.ReportInfo.feature_usage:type_name -> livekit.FeatureUsageInfo
+	20, // 37: livekit.TimeRange.started_at:type_name -> google.protobuf.Timestamp
+	20, // 38: livekit.TimeRange.ended_at:type_name -> google.protobuf.Timestamp
+	2,  // 39: livekit.FeatureUsageInfo.feature:type_name -> livekit.FeatureUsageInfo.Feature
+	14, // 40: livekit.FeatureUsageInfo.time_ranges:type_name -> livekit.TimeRange
+	19, // 41: livekit.FeatureUsageInfo.feature_info:type_name -> livekit.FeatureUsageInfo.FeatureInfoEntry
+	37, // 42: livekit.APICallRequest.create_room_request:type_name -> livekit.CreateRoomRequest
+	38, // 43: livekit.APICallRequest.list_rooms_request:type_name -> livekit.ListRoomsRequest
+	39, // 44: livekit.APICallRequest.delete_room_request:type_name -> livekit.DeleteRoomRequest
+	40, // 45: livekit.APICallRequest.list_participants_request:type_name -> livekit.ListParticipantsRequest
+	41, // 46: livekit.APICallRequest.room_participant_identity:type_name -> livekit.RoomParticipantIdentity
+	42, // 47: livekit.APICallRequest.mute_room_track_request:type_name -> livekit.MuteRoomTrackRequest
+	43, // 48: livekit.APICallRequest.update_participant_request:type_name -> livekit.UpdateParticipantRequest
+	44, // 49: livekit.APICallRequest.update_subscriptions_request:type_name -> livekit.UpdateSubscriptionsRequest
+	45, // 50: livekit.APICallRequest.send_data_request:type_name -> livekit.SendDataRequest
+	46, // 51: livekit.APICallRequest.update_room_metadata_request:type_name -> livekit.UpdateRoomMetadataRequest
+	16, // 52: livekit.APICallInfo.request:type_name -> livekit.APICallRequest
+	20, // 53: livekit.APICallInfo.started_at:type_name -> google.protobuf.Timestamp
+	20, // 54: livekit.WebhookInfo.created_at:type_name -> google.protobuf.Timestamp
+	20, // 55: livekit.WebhookInfo.queued_at:type_name -> google.protobuf.Timestamp
+	20, // 56: livekit.WebhookInfo.sent_at:type_name -> google.protobuf.Timestamp
+	57, // [57:57] is the sub-list for method output_type
+	57, // [57:57] is the sub-list for method input_type
+	57, // [57:57] is the sub-list for extension type_name
+	57, // [57:57] is the sub-list for extension extendee
+	0,  // [0:57] is the sub-list for field type_name
 }
 
 func init() { file_livekit_analytics_proto_init() }

--- a/livekit/livekit_models.pb.go
+++ b/livekit/livekit_models.pb.go
@@ -654,6 +654,70 @@ func (DisconnectReason) EnumDescriptor() ([]byte, []int) {
 	return file_livekit_models_proto_rawDescGZIP(), []int{10}
 }
 
+// why a room ended, reported on room-ended telemetry
+type RoomEndReason int32
+
+const (
+	RoomEndReason_ROOM_END_UNKNOWN RoomEndReason = 0
+	// RoomService.DeleteRoom was called
+	RoomEndReason_ROOM_END_API_DELETE RoomEndReason = 1
+	// the room sat empty past its empty or departure timeout
+	RoomEndReason_ROOM_END_IDLE_TIMEOUT RoomEndReason = 2
+	// the server instance is shutting down
+	RoomEndReason_ROOM_END_SERVER_SHUTDOWN RoomEndReason = 3
+	// the room was restarted or replaced elsewhere
+	RoomEndReason_ROOM_END_SUPERSEDED RoomEndReason = 4
+	// the room failed to finish opening
+	RoomEndReason_ROOM_END_OPEN_FAILED RoomEndReason = 5
+)
+
+// Enum value maps for RoomEndReason.
+var (
+	RoomEndReason_name = map[int32]string{
+		0: "ROOM_END_UNKNOWN",
+		1: "ROOM_END_API_DELETE",
+		2: "ROOM_END_IDLE_TIMEOUT",
+		3: "ROOM_END_SERVER_SHUTDOWN",
+		4: "ROOM_END_SUPERSEDED",
+		5: "ROOM_END_OPEN_FAILED",
+	}
+	RoomEndReason_value = map[string]int32{
+		"ROOM_END_UNKNOWN":         0,
+		"ROOM_END_API_DELETE":      1,
+		"ROOM_END_IDLE_TIMEOUT":    2,
+		"ROOM_END_SERVER_SHUTDOWN": 3,
+		"ROOM_END_SUPERSEDED":      4,
+		"ROOM_END_OPEN_FAILED":     5,
+	}
+)
+
+func (x RoomEndReason) Enum() *RoomEndReason {
+	p := new(RoomEndReason)
+	*p = x
+	return p
+}
+
+func (x RoomEndReason) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RoomEndReason) Descriptor() protoreflect.EnumDescriptor {
+	return file_livekit_models_proto_enumTypes[11].Descriptor()
+}
+
+func (RoomEndReason) Type() protoreflect.EnumType {
+	return &file_livekit_models_proto_enumTypes[11]
+}
+
+func (x RoomEndReason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RoomEndReason.Descriptor instead.
+func (RoomEndReason) EnumDescriptor() ([]byte, []int) {
+	return file_livekit_models_proto_rawDescGZIP(), []int{11}
+}
+
 type ReconnectReason int32
 
 const (
@@ -693,11 +757,11 @@ func (x ReconnectReason) String() string {
 }
 
 func (ReconnectReason) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[11].Descriptor()
+	return file_livekit_models_proto_enumTypes[12].Descriptor()
 }
 
 func (ReconnectReason) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[11]
+	return &file_livekit_models_proto_enumTypes[12]
 }
 
 func (x ReconnectReason) Number() protoreflect.EnumNumber {
@@ -706,7 +770,7 @@ func (x ReconnectReason) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ReconnectReason.Descriptor instead.
 func (ReconnectReason) EnumDescriptor() ([]byte, []int) {
-	return file_livekit_models_proto_rawDescGZIP(), []int{11}
+	return file_livekit_models_proto_rawDescGZIP(), []int{12}
 }
 
 type SubscriptionError int32
@@ -742,11 +806,11 @@ func (x SubscriptionError) String() string {
 }
 
 func (SubscriptionError) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[12].Descriptor()
+	return file_livekit_models_proto_enumTypes[13].Descriptor()
 }
 
 func (SubscriptionError) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[12]
+	return &file_livekit_models_proto_enumTypes[13]
 }
 
 func (x SubscriptionError) Number() protoreflect.EnumNumber {
@@ -755,7 +819,7 @@ func (x SubscriptionError) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SubscriptionError.Descriptor instead.
 func (SubscriptionError) EnumDescriptor() ([]byte, []int) {
-	return file_livekit_models_proto_rawDescGZIP(), []int{12}
+	return file_livekit_models_proto_rawDescGZIP(), []int{13}
 }
 
 type AudioTrackFeature int32
@@ -803,11 +867,11 @@ func (x AudioTrackFeature) String() string {
 }
 
 func (AudioTrackFeature) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[13].Descriptor()
+	return file_livekit_models_proto_enumTypes[14].Descriptor()
 }
 
 func (AudioTrackFeature) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[13]
+	return &file_livekit_models_proto_enumTypes[14]
 }
 
 func (x AudioTrackFeature) Number() protoreflect.EnumNumber {
@@ -816,7 +880,7 @@ func (x AudioTrackFeature) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AudioTrackFeature.Descriptor instead.
 func (AudioTrackFeature) EnumDescriptor() ([]byte, []int) {
-	return file_livekit_models_proto_rawDescGZIP(), []int{13}
+	return file_livekit_models_proto_rawDescGZIP(), []int{14}
 }
 
 type PacketTrailerFeature int32
@@ -852,11 +916,11 @@ func (x PacketTrailerFeature) String() string {
 }
 
 func (PacketTrailerFeature) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[14].Descriptor()
+	return file_livekit_models_proto_enumTypes[15].Descriptor()
 }
 
 func (PacketTrailerFeature) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[14]
+	return &file_livekit_models_proto_enumTypes[15]
 }
 
 func (x PacketTrailerFeature) Number() protoreflect.EnumNumber {
@@ -865,7 +929,7 @@ func (x PacketTrailerFeature) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PacketTrailerFeature.Descriptor instead.
 func (PacketTrailerFeature) EnumDescriptor() ([]byte, []int) {
-	return file_livekit_models_proto_rawDescGZIP(), []int{14}
+	return file_livekit_models_proto_rawDescGZIP(), []int{15}
 }
 
 type ParticipantInfo_State int32
@@ -908,11 +972,11 @@ func (x ParticipantInfo_State) String() string {
 }
 
 func (ParticipantInfo_State) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[15].Descriptor()
+	return file_livekit_models_proto_enumTypes[16].Descriptor()
 }
 
 func (ParticipantInfo_State) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[15]
+	return &file_livekit_models_proto_enumTypes[16]
 }
 
 func (x ParticipantInfo_State) Number() protoreflect.EnumNumber {
@@ -976,11 +1040,11 @@ func (x ParticipantInfo_Kind) String() string {
 }
 
 func (ParticipantInfo_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[16].Descriptor()
+	return file_livekit_models_proto_enumTypes[17].Descriptor()
 }
 
 func (ParticipantInfo_Kind) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[16]
+	return &file_livekit_models_proto_enumTypes[17]
 }
 
 func (x ParticipantInfo_Kind) Number() protoreflect.EnumNumber {
@@ -1034,11 +1098,11 @@ func (x ParticipantInfo_KindDetail) String() string {
 }
 
 func (ParticipantInfo_KindDetail) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[17].Descriptor()
+	return file_livekit_models_proto_enumTypes[18].Descriptor()
 }
 
 func (ParticipantInfo_KindDetail) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[17]
+	return &file_livekit_models_proto_enumTypes[18]
 }
 
 func (x ParticipantInfo_KindDetail) Number() protoreflect.EnumNumber {
@@ -1083,11 +1147,11 @@ func (x Encryption_Type) String() string {
 }
 
 func (Encryption_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[18].Descriptor()
+	return file_livekit_models_proto_enumTypes[19].Descriptor()
 }
 
 func (Encryption_Type) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[18]
+	return &file_livekit_models_proto_enumTypes[19]
 }
 
 func (x Encryption_Type) Number() protoreflect.EnumNumber {
@@ -1158,11 +1222,11 @@ func (x DataTrackFrameEncoding_WellKnownFrameEncoding) String() string {
 }
 
 func (DataTrackFrameEncoding_WellKnownFrameEncoding) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[19].Descriptor()
+	return file_livekit_models_proto_enumTypes[20].Descriptor()
 }
 
 func (DataTrackFrameEncoding_WellKnownFrameEncoding) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[19]
+	return &file_livekit_models_proto_enumTypes[20]
 }
 
 func (x DataTrackFrameEncoding_WellKnownFrameEncoding) Number() protoreflect.EnumNumber {
@@ -1233,11 +1297,11 @@ func (x DataTrackSchemaEncoding_WellKnownSchemaEncoding) String() string {
 }
 
 func (DataTrackSchemaEncoding_WellKnownSchemaEncoding) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[20].Descriptor()
+	return file_livekit_models_proto_enumTypes[21].Descriptor()
 }
 
 func (DataTrackSchemaEncoding_WellKnownSchemaEncoding) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[20]
+	return &file_livekit_models_proto_enumTypes[21]
 }
 
 func (x DataTrackSchemaEncoding_WellKnownSchemaEncoding) Number() protoreflect.EnumNumber {
@@ -1285,11 +1349,11 @@ func (x VideoLayer_Mode) String() string {
 }
 
 func (VideoLayer_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[21].Descriptor()
+	return file_livekit_models_proto_enumTypes[22].Descriptor()
 }
 
 func (VideoLayer_Mode) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[21]
+	return &file_livekit_models_proto_enumTypes[22]
 }
 
 func (x VideoLayer_Mode) Number() protoreflect.EnumNumber {
@@ -1331,11 +1395,11 @@ func (x DataPacket_Kind) String() string {
 }
 
 func (DataPacket_Kind) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[22].Descriptor()
+	return file_livekit_models_proto_enumTypes[23].Descriptor()
 }
 
 func (DataPacket_Kind) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[22]
+	return &file_livekit_models_proto_enumTypes[23]
 }
 
 func (x DataPacket_Kind) Number() protoreflect.EnumNumber {
@@ -1377,11 +1441,11 @@ func (x ServerInfo_Edition) String() string {
 }
 
 func (ServerInfo_Edition) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[23].Descriptor()
+	return file_livekit_models_proto_enumTypes[24].Descriptor()
 }
 
 func (ServerInfo_Edition) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[23]
+	return &file_livekit_models_proto_enumTypes[24]
 }
 
 func (x ServerInfo_Edition) Number() protoreflect.EnumNumber {
@@ -1462,11 +1526,11 @@ func (x ClientInfo_SDK) String() string {
 }
 
 func (ClientInfo_SDK) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[24].Descriptor()
+	return file_livekit_models_proto_enumTypes[25].Descriptor()
 }
 
 func (ClientInfo_SDK) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[24]
+	return &file_livekit_models_proto_enumTypes[25]
 }
 
 func (x ClientInfo_SDK) Number() protoreflect.EnumNumber {
@@ -1515,11 +1579,11 @@ func (x ClientInfo_Capability) String() string {
 }
 
 func (ClientInfo_Capability) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[25].Descriptor()
+	return file_livekit_models_proto_enumTypes[26].Descriptor()
 }
 
 func (ClientInfo_Capability) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[25]
+	return &file_livekit_models_proto_enumTypes[26]
 }
 
 func (x ClientInfo_Capability) Number() protoreflect.EnumNumber {
@@ -1568,11 +1632,11 @@ func (x DataStream_OperationType) String() string {
 }
 
 func (DataStream_OperationType) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[26].Descriptor()
+	return file_livekit_models_proto_enumTypes[27].Descriptor()
 }
 
 func (DataStream_OperationType) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[26]
+	return &file_livekit_models_proto_enumTypes[27]
 }
 
 func (x DataStream_OperationType) Number() protoreflect.EnumNumber {
@@ -1618,11 +1682,11 @@ func (x DataStream_CompressionType) String() string {
 }
 
 func (DataStream_CompressionType) Descriptor() protoreflect.EnumDescriptor {
-	return file_livekit_models_proto_enumTypes[27].Descriptor()
+	return file_livekit_models_proto_enumTypes[28].Descriptor()
 }
 
 func (DataStream_CompressionType) Type() protoreflect.EnumType {
-	return &file_livekit_models_proto_enumTypes[27]
+	return &file_livekit_models_proto_enumTypes[28]
 }
 
 func (x DataStream_CompressionType) Number() protoreflect.EnumNumber {
@@ -7467,7 +7531,14 @@ const file_livekit_models_proto_rawDesc = "" +
 	"\x11SIP_TRUNK_FAILURE\x10\r\x12\x16\n" +
 	"\x12CONNECTION_TIMEOUT\x10\x0e\x12\x11\n" +
 	"\rMEDIA_FAILURE\x10\x0f\x12\x0f\n" +
-	"\vAGENT_ERROR\x10\x10*\x89\x01\n" +
+	"\vAGENT_ERROR\x10\x10*\xaa\x01\n" +
+	"\rRoomEndReason\x12\x14\n" +
+	"\x10ROOM_END_UNKNOWN\x10\x00\x12\x17\n" +
+	"\x13ROOM_END_API_DELETE\x10\x01\x12\x19\n" +
+	"\x15ROOM_END_IDLE_TIMEOUT\x10\x02\x12\x1c\n" +
+	"\x18ROOM_END_SERVER_SHUTDOWN\x10\x03\x12\x17\n" +
+	"\x13ROOM_END_SUPERSEDED\x10\x04\x12\x18\n" +
+	"\x14ROOM_END_OPEN_FAILED\x10\x05*\x89\x01\n" +
 	"\x0fReconnectReason\x12\x0e\n" +
 	"\n" +
 	"RR_UNKNOWN\x10\x00\x12\x1a\n" +
@@ -7505,7 +7576,7 @@ func file_livekit_models_proto_rawDescGZIP() []byte {
 	return file_livekit_models_proto_rawDescData
 }
 
-var file_livekit_models_proto_enumTypes = make([]protoimpl.EnumInfo, 28)
+var file_livekit_models_proto_enumTypes = make([]protoimpl.EnumInfo, 29)
 var file_livekit_models_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
 var file_livekit_models_proto_goTypes = []any{
 	(AudioCodec)(0),                                      // 0: livekit.AudioCodec
@@ -7519,181 +7590,182 @@ var file_livekit_models_proto_goTypes = []any{
 	(ConnectionQuality)(0),                               // 8: livekit.ConnectionQuality
 	(ClientConfigSetting)(0),                             // 9: livekit.ClientConfigSetting
 	(DisconnectReason)(0),                                // 10: livekit.DisconnectReason
-	(ReconnectReason)(0),                                 // 11: livekit.ReconnectReason
-	(SubscriptionError)(0),                               // 12: livekit.SubscriptionError
-	(AudioTrackFeature)(0),                               // 13: livekit.AudioTrackFeature
-	(PacketTrailerFeature)(0),                            // 14: livekit.PacketTrailerFeature
-	(ParticipantInfo_State)(0),                           // 15: livekit.ParticipantInfo.State
-	(ParticipantInfo_Kind)(0),                            // 16: livekit.ParticipantInfo.Kind
-	(ParticipantInfo_KindDetail)(0),                      // 17: livekit.ParticipantInfo.KindDetail
-	(Encryption_Type)(0),                                 // 18: livekit.Encryption.Type
-	(DataTrackFrameEncoding_WellKnownFrameEncoding)(0),   // 19: livekit.DataTrackFrameEncoding.WellKnownFrameEncoding
-	(DataTrackSchemaEncoding_WellKnownSchemaEncoding)(0), // 20: livekit.DataTrackSchemaEncoding.WellKnownSchemaEncoding
-	(VideoLayer_Mode)(0),                                 // 21: livekit.VideoLayer.Mode
-	(DataPacket_Kind)(0),                                 // 22: livekit.DataPacket.Kind
-	(ServerInfo_Edition)(0),                              // 23: livekit.ServerInfo.Edition
-	(ClientInfo_SDK)(0),                                  // 24: livekit.ClientInfo.SDK
-	(ClientInfo_Capability)(0),                           // 25: livekit.ClientInfo.Capability
-	(DataStream_OperationType)(0),                        // 26: livekit.DataStream.OperationType
-	(DataStream_CompressionType)(0),                      // 27: livekit.DataStream.CompressionType
-	(*Pagination)(nil),                                   // 28: livekit.Pagination
-	(*TokenPagination)(nil),                              // 29: livekit.TokenPagination
-	(*ListUpdate)(nil),                                   // 30: livekit.ListUpdate
-	(*Room)(nil),                                         // 31: livekit.Room
-	(*Codec)(nil),                                        // 32: livekit.Codec
-	(*PlayoutDelay)(nil),                                 // 33: livekit.PlayoutDelay
-	(*ParticipantPermission)(nil),                        // 34: livekit.ParticipantPermission
-	(*ParticipantInfo)(nil),                              // 35: livekit.ParticipantInfo
-	(*Encryption)(nil),                                   // 36: livekit.Encryption
-	(*SimulcastCodecInfo)(nil),                           // 37: livekit.SimulcastCodecInfo
-	(*TrackInfo)(nil),                                    // 38: livekit.TrackInfo
-	(*DataTrackInfo)(nil),                                // 39: livekit.DataTrackInfo
-	(*DataTrackFrameEncoding)(nil),                       // 40: livekit.DataTrackFrameEncoding
-	(*DataTrackSchemaEncoding)(nil),                      // 41: livekit.DataTrackSchemaEncoding
-	(*DataTrackSchemaId)(nil),                            // 42: livekit.DataTrackSchemaId
-	(*DataTrackExtensionParticipantSid)(nil),             // 43: livekit.DataTrackExtensionParticipantSid
-	(*DataTrackSubscriptionOptions)(nil),                 // 44: livekit.DataTrackSubscriptionOptions
-	(*DataBlobKey)(nil),                                  // 45: livekit.DataBlobKey
-	(*DataBlob)(nil),                                     // 46: livekit.DataBlob
-	(*VideoLayer)(nil),                                   // 47: livekit.VideoLayer
-	(*DataPacket)(nil),                                   // 48: livekit.DataPacket
-	(*EncryptedPacket)(nil),                              // 49: livekit.EncryptedPacket
-	(*EncryptedPacketPayload)(nil),                       // 50: livekit.EncryptedPacketPayload
-	(*ActiveSpeakerUpdate)(nil),                          // 51: livekit.ActiveSpeakerUpdate
-	(*SpeakerInfo)(nil),                                  // 52: livekit.SpeakerInfo
-	(*UserPacket)(nil),                                   // 53: livekit.UserPacket
-	(*SipDTMF)(nil),                                      // 54: livekit.SipDTMF
-	(*Transcription)(nil),                                // 55: livekit.Transcription
-	(*TranscriptionSegment)(nil),                         // 56: livekit.TranscriptionSegment
-	(*ChatMessage)(nil),                                  // 57: livekit.ChatMessage
-	(*RpcRequest)(nil),                                   // 58: livekit.RpcRequest
-	(*RpcAck)(nil),                                       // 59: livekit.RpcAck
-	(*RpcResponse)(nil),                                  // 60: livekit.RpcResponse
-	(*RpcError)(nil),                                     // 61: livekit.RpcError
-	(*ParticipantTracks)(nil),                            // 62: livekit.ParticipantTracks
-	(*ServerInfo)(nil),                                   // 63: livekit.ServerInfo
-	(*ClientInfo)(nil),                                   // 64: livekit.ClientInfo
-	(*ClientConfiguration)(nil),                          // 65: livekit.ClientConfiguration
-	(*VideoConfiguration)(nil),                           // 66: livekit.VideoConfiguration
-	(*DisabledCodecs)(nil),                               // 67: livekit.DisabledCodecs
-	(*RTPDrift)(nil),                                     // 68: livekit.RTPDrift
-	(*RTPStats)(nil),                                     // 69: livekit.RTPStats
-	(*RTCPSenderReportState)(nil),                        // 70: livekit.RTCPSenderReportState
-	(*RTPForwarderState)(nil),                            // 71: livekit.RTPForwarderState
-	(*RTPMungerState)(nil),                               // 72: livekit.RTPMungerState
-	(*VP8MungerState)(nil),                               // 73: livekit.VP8MungerState
-	(*TimedVersion)(nil),                                 // 74: livekit.TimedVersion
-	(*DataStream)(nil),                                   // 75: livekit.DataStream
-	(*FilterParams)(nil),                                 // 76: livekit.FilterParams
-	(*WebhookConfig)(nil),                                // 77: livekit.WebhookConfig
-	(*SubscribedAudioCodec)(nil),                         // 78: livekit.SubscribedAudioCodec
-	nil,                                                  // 79: livekit.ParticipantInfo.AttributesEntry
-	nil,                                                  // 80: livekit.RTPStats.GapHistogramEntry
-	(*DataStream_TextHeader)(nil),                        // 81: livekit.DataStream.TextHeader
-	(*DataStream_ByteHeader)(nil),                        // 82: livekit.DataStream.ByteHeader
-	(*DataStream_Header)(nil),                            // 83: livekit.DataStream.Header
-	(*DataStream_Chunk)(nil),                             // 84: livekit.DataStream.Chunk
-	(*DataStream_Trailer)(nil),                           // 85: livekit.DataStream.Trailer
-	nil,                                                  // 86: livekit.DataStream.Header.AttributesEntry
-	nil,                                                  // 87: livekit.DataStream.Trailer.AttributesEntry
-	(*MetricsBatch)(nil),                                 // 88: livekit.MetricsBatch
-	(*timestamppb.Timestamp)(nil),                        // 89: google.protobuf.Timestamp
+	(RoomEndReason)(0),                                   // 11: livekit.RoomEndReason
+	(ReconnectReason)(0),                                 // 12: livekit.ReconnectReason
+	(SubscriptionError)(0),                               // 13: livekit.SubscriptionError
+	(AudioTrackFeature)(0),                               // 14: livekit.AudioTrackFeature
+	(PacketTrailerFeature)(0),                            // 15: livekit.PacketTrailerFeature
+	(ParticipantInfo_State)(0),                           // 16: livekit.ParticipantInfo.State
+	(ParticipantInfo_Kind)(0),                            // 17: livekit.ParticipantInfo.Kind
+	(ParticipantInfo_KindDetail)(0),                      // 18: livekit.ParticipantInfo.KindDetail
+	(Encryption_Type)(0),                                 // 19: livekit.Encryption.Type
+	(DataTrackFrameEncoding_WellKnownFrameEncoding)(0),   // 20: livekit.DataTrackFrameEncoding.WellKnownFrameEncoding
+	(DataTrackSchemaEncoding_WellKnownSchemaEncoding)(0), // 21: livekit.DataTrackSchemaEncoding.WellKnownSchemaEncoding
+	(VideoLayer_Mode)(0),                                 // 22: livekit.VideoLayer.Mode
+	(DataPacket_Kind)(0),                                 // 23: livekit.DataPacket.Kind
+	(ServerInfo_Edition)(0),                              // 24: livekit.ServerInfo.Edition
+	(ClientInfo_SDK)(0),                                  // 25: livekit.ClientInfo.SDK
+	(ClientInfo_Capability)(0),                           // 26: livekit.ClientInfo.Capability
+	(DataStream_OperationType)(0),                        // 27: livekit.DataStream.OperationType
+	(DataStream_CompressionType)(0),                      // 28: livekit.DataStream.CompressionType
+	(*Pagination)(nil),                                   // 29: livekit.Pagination
+	(*TokenPagination)(nil),                              // 30: livekit.TokenPagination
+	(*ListUpdate)(nil),                                   // 31: livekit.ListUpdate
+	(*Room)(nil),                                         // 32: livekit.Room
+	(*Codec)(nil),                                        // 33: livekit.Codec
+	(*PlayoutDelay)(nil),                                 // 34: livekit.PlayoutDelay
+	(*ParticipantPermission)(nil),                        // 35: livekit.ParticipantPermission
+	(*ParticipantInfo)(nil),                              // 36: livekit.ParticipantInfo
+	(*Encryption)(nil),                                   // 37: livekit.Encryption
+	(*SimulcastCodecInfo)(nil),                           // 38: livekit.SimulcastCodecInfo
+	(*TrackInfo)(nil),                                    // 39: livekit.TrackInfo
+	(*DataTrackInfo)(nil),                                // 40: livekit.DataTrackInfo
+	(*DataTrackFrameEncoding)(nil),                       // 41: livekit.DataTrackFrameEncoding
+	(*DataTrackSchemaEncoding)(nil),                      // 42: livekit.DataTrackSchemaEncoding
+	(*DataTrackSchemaId)(nil),                            // 43: livekit.DataTrackSchemaId
+	(*DataTrackExtensionParticipantSid)(nil),             // 44: livekit.DataTrackExtensionParticipantSid
+	(*DataTrackSubscriptionOptions)(nil),                 // 45: livekit.DataTrackSubscriptionOptions
+	(*DataBlobKey)(nil),                                  // 46: livekit.DataBlobKey
+	(*DataBlob)(nil),                                     // 47: livekit.DataBlob
+	(*VideoLayer)(nil),                                   // 48: livekit.VideoLayer
+	(*DataPacket)(nil),                                   // 49: livekit.DataPacket
+	(*EncryptedPacket)(nil),                              // 50: livekit.EncryptedPacket
+	(*EncryptedPacketPayload)(nil),                       // 51: livekit.EncryptedPacketPayload
+	(*ActiveSpeakerUpdate)(nil),                          // 52: livekit.ActiveSpeakerUpdate
+	(*SpeakerInfo)(nil),                                  // 53: livekit.SpeakerInfo
+	(*UserPacket)(nil),                                   // 54: livekit.UserPacket
+	(*SipDTMF)(nil),                                      // 55: livekit.SipDTMF
+	(*Transcription)(nil),                                // 56: livekit.Transcription
+	(*TranscriptionSegment)(nil),                         // 57: livekit.TranscriptionSegment
+	(*ChatMessage)(nil),                                  // 58: livekit.ChatMessage
+	(*RpcRequest)(nil),                                   // 59: livekit.RpcRequest
+	(*RpcAck)(nil),                                       // 60: livekit.RpcAck
+	(*RpcResponse)(nil),                                  // 61: livekit.RpcResponse
+	(*RpcError)(nil),                                     // 62: livekit.RpcError
+	(*ParticipantTracks)(nil),                            // 63: livekit.ParticipantTracks
+	(*ServerInfo)(nil),                                   // 64: livekit.ServerInfo
+	(*ClientInfo)(nil),                                   // 65: livekit.ClientInfo
+	(*ClientConfiguration)(nil),                          // 66: livekit.ClientConfiguration
+	(*VideoConfiguration)(nil),                           // 67: livekit.VideoConfiguration
+	(*DisabledCodecs)(nil),                               // 68: livekit.DisabledCodecs
+	(*RTPDrift)(nil),                                     // 69: livekit.RTPDrift
+	(*RTPStats)(nil),                                     // 70: livekit.RTPStats
+	(*RTCPSenderReportState)(nil),                        // 71: livekit.RTCPSenderReportState
+	(*RTPForwarderState)(nil),                            // 72: livekit.RTPForwarderState
+	(*RTPMungerState)(nil),                               // 73: livekit.RTPMungerState
+	(*VP8MungerState)(nil),                               // 74: livekit.VP8MungerState
+	(*TimedVersion)(nil),                                 // 75: livekit.TimedVersion
+	(*DataStream)(nil),                                   // 76: livekit.DataStream
+	(*FilterParams)(nil),                                 // 77: livekit.FilterParams
+	(*WebhookConfig)(nil),                                // 78: livekit.WebhookConfig
+	(*SubscribedAudioCodec)(nil),                         // 79: livekit.SubscribedAudioCodec
+	nil,                                                  // 80: livekit.ParticipantInfo.AttributesEntry
+	nil,                                                  // 81: livekit.RTPStats.GapHistogramEntry
+	(*DataStream_TextHeader)(nil),                        // 82: livekit.DataStream.TextHeader
+	(*DataStream_ByteHeader)(nil),                        // 83: livekit.DataStream.ByteHeader
+	(*DataStream_Header)(nil),                            // 84: livekit.DataStream.Header
+	(*DataStream_Chunk)(nil),                             // 85: livekit.DataStream.Chunk
+	(*DataStream_Trailer)(nil),                           // 86: livekit.DataStream.Trailer
+	nil,                                                  // 87: livekit.DataStream.Header.AttributesEntry
+	nil,                                                  // 88: livekit.DataStream.Trailer.AttributesEntry
+	(*MetricsBatch)(nil),                                 // 89: livekit.MetricsBatch
+	(*timestamppb.Timestamp)(nil),                        // 90: google.protobuf.Timestamp
 }
 var file_livekit_models_proto_depIdxs = []int32{
-	32, // 0: livekit.Room.enabled_codecs:type_name -> livekit.Codec
-	74, // 1: livekit.Room.version:type_name -> livekit.TimedVersion
+	33, // 0: livekit.Room.enabled_codecs:type_name -> livekit.Codec
+	75, // 1: livekit.Room.version:type_name -> livekit.TimedVersion
 	5,  // 2: livekit.ParticipantPermission.can_publish_sources:type_name -> livekit.TrackSource
-	15, // 3: livekit.ParticipantInfo.state:type_name -> livekit.ParticipantInfo.State
-	38, // 4: livekit.ParticipantInfo.tracks:type_name -> livekit.TrackInfo
-	34, // 5: livekit.ParticipantInfo.permission:type_name -> livekit.ParticipantPermission
-	16, // 6: livekit.ParticipantInfo.kind:type_name -> livekit.ParticipantInfo.Kind
-	79, // 7: livekit.ParticipantInfo.attributes:type_name -> livekit.ParticipantInfo.AttributesEntry
+	16, // 3: livekit.ParticipantInfo.state:type_name -> livekit.ParticipantInfo.State
+	39, // 4: livekit.ParticipantInfo.tracks:type_name -> livekit.TrackInfo
+	35, // 5: livekit.ParticipantInfo.permission:type_name -> livekit.ParticipantPermission
+	17, // 6: livekit.ParticipantInfo.kind:type_name -> livekit.ParticipantInfo.Kind
+	80, // 7: livekit.ParticipantInfo.attributes:type_name -> livekit.ParticipantInfo.AttributesEntry
 	10, // 8: livekit.ParticipantInfo.disconnect_reason:type_name -> livekit.DisconnectReason
-	17, // 9: livekit.ParticipantInfo.kind_details:type_name -> livekit.ParticipantInfo.KindDetail
-	39, // 10: livekit.ParticipantInfo.data_tracks:type_name -> livekit.DataTrackInfo
-	25, // 11: livekit.ParticipantInfo.capabilities:type_name -> livekit.ClientInfo.Capability
-	47, // 12: livekit.SimulcastCodecInfo.layers:type_name -> livekit.VideoLayer
-	21, // 13: livekit.SimulcastCodecInfo.video_layer_mode:type_name -> livekit.VideoLayer.Mode
+	18, // 9: livekit.ParticipantInfo.kind_details:type_name -> livekit.ParticipantInfo.KindDetail
+	40, // 10: livekit.ParticipantInfo.data_tracks:type_name -> livekit.DataTrackInfo
+	26, // 11: livekit.ParticipantInfo.capabilities:type_name -> livekit.ClientInfo.Capability
+	48, // 12: livekit.SimulcastCodecInfo.layers:type_name -> livekit.VideoLayer
+	22, // 13: livekit.SimulcastCodecInfo.video_layer_mode:type_name -> livekit.VideoLayer.Mode
 	4,  // 14: livekit.TrackInfo.type:type_name -> livekit.TrackType
 	5,  // 15: livekit.TrackInfo.source:type_name -> livekit.TrackSource
-	47, // 16: livekit.TrackInfo.layers:type_name -> livekit.VideoLayer
-	37, // 17: livekit.TrackInfo.codecs:type_name -> livekit.SimulcastCodecInfo
-	18, // 18: livekit.TrackInfo.encryption:type_name -> livekit.Encryption.Type
-	74, // 19: livekit.TrackInfo.version:type_name -> livekit.TimedVersion
-	13, // 20: livekit.TrackInfo.audio_features:type_name -> livekit.AudioTrackFeature
+	48, // 16: livekit.TrackInfo.layers:type_name -> livekit.VideoLayer
+	38, // 17: livekit.TrackInfo.codecs:type_name -> livekit.SimulcastCodecInfo
+	19, // 18: livekit.TrackInfo.encryption:type_name -> livekit.Encryption.Type
+	75, // 19: livekit.TrackInfo.version:type_name -> livekit.TimedVersion
+	14, // 20: livekit.TrackInfo.audio_features:type_name -> livekit.AudioTrackFeature
 	3,  // 21: livekit.TrackInfo.backup_codec_policy:type_name -> livekit.BackupCodecPolicy
-	14, // 22: livekit.TrackInfo.packet_trailer_features:type_name -> livekit.PacketTrailerFeature
-	18, // 23: livekit.DataTrackInfo.encryption:type_name -> livekit.Encryption.Type
-	40, // 24: livekit.DataTrackInfo.frame_encoding:type_name -> livekit.DataTrackFrameEncoding
-	42, // 25: livekit.DataTrackInfo.schema:type_name -> livekit.DataTrackSchemaId
-	19, // 26: livekit.DataTrackFrameEncoding.well_known:type_name -> livekit.DataTrackFrameEncoding.WellKnownFrameEncoding
-	20, // 27: livekit.DataTrackSchemaEncoding.well_known:type_name -> livekit.DataTrackSchemaEncoding.WellKnownSchemaEncoding
-	41, // 28: livekit.DataTrackSchemaId.encoding:type_name -> livekit.DataTrackSchemaEncoding
+	15, // 22: livekit.TrackInfo.packet_trailer_features:type_name -> livekit.PacketTrailerFeature
+	19, // 23: livekit.DataTrackInfo.encryption:type_name -> livekit.Encryption.Type
+	41, // 24: livekit.DataTrackInfo.frame_encoding:type_name -> livekit.DataTrackFrameEncoding
+	43, // 25: livekit.DataTrackInfo.schema:type_name -> livekit.DataTrackSchemaId
+	20, // 26: livekit.DataTrackFrameEncoding.well_known:type_name -> livekit.DataTrackFrameEncoding.WellKnownFrameEncoding
+	21, // 27: livekit.DataTrackSchemaEncoding.well_known:type_name -> livekit.DataTrackSchemaEncoding.WellKnownSchemaEncoding
+	42, // 28: livekit.DataTrackSchemaId.encoding:type_name -> livekit.DataTrackSchemaEncoding
 	6,  // 29: livekit.DataTrackExtensionParticipantSid.id:type_name -> livekit.DataTrackExtensionID
-	42, // 30: livekit.DataBlobKey.schema_id:type_name -> livekit.DataTrackSchemaId
-	45, // 31: livekit.DataBlob.key:type_name -> livekit.DataBlobKey
+	43, // 30: livekit.DataBlobKey.schema_id:type_name -> livekit.DataTrackSchemaId
+	46, // 31: livekit.DataBlob.key:type_name -> livekit.DataBlobKey
 	7,  // 32: livekit.VideoLayer.quality:type_name -> livekit.VideoQuality
-	22, // 33: livekit.DataPacket.kind:type_name -> livekit.DataPacket.Kind
-	53, // 34: livekit.DataPacket.user:type_name -> livekit.UserPacket
-	51, // 35: livekit.DataPacket.speaker:type_name -> livekit.ActiveSpeakerUpdate
-	54, // 36: livekit.DataPacket.sip_dtmf:type_name -> livekit.SipDTMF
-	55, // 37: livekit.DataPacket.transcription:type_name -> livekit.Transcription
-	88, // 38: livekit.DataPacket.metrics:type_name -> livekit.MetricsBatch
-	57, // 39: livekit.DataPacket.chat_message:type_name -> livekit.ChatMessage
-	58, // 40: livekit.DataPacket.rpc_request:type_name -> livekit.RpcRequest
-	59, // 41: livekit.DataPacket.rpc_ack:type_name -> livekit.RpcAck
-	60, // 42: livekit.DataPacket.rpc_response:type_name -> livekit.RpcResponse
-	83, // 43: livekit.DataPacket.stream_header:type_name -> livekit.DataStream.Header
-	84, // 44: livekit.DataPacket.stream_chunk:type_name -> livekit.DataStream.Chunk
-	85, // 45: livekit.DataPacket.stream_trailer:type_name -> livekit.DataStream.Trailer
-	49, // 46: livekit.DataPacket.encrypted_packet:type_name -> livekit.EncryptedPacket
-	18, // 47: livekit.EncryptedPacket.encryption_type:type_name -> livekit.Encryption.Type
-	53, // 48: livekit.EncryptedPacketPayload.user:type_name -> livekit.UserPacket
-	57, // 49: livekit.EncryptedPacketPayload.chat_message:type_name -> livekit.ChatMessage
-	58, // 50: livekit.EncryptedPacketPayload.rpc_request:type_name -> livekit.RpcRequest
-	59, // 51: livekit.EncryptedPacketPayload.rpc_ack:type_name -> livekit.RpcAck
-	60, // 52: livekit.EncryptedPacketPayload.rpc_response:type_name -> livekit.RpcResponse
-	83, // 53: livekit.EncryptedPacketPayload.stream_header:type_name -> livekit.DataStream.Header
-	84, // 54: livekit.EncryptedPacketPayload.stream_chunk:type_name -> livekit.DataStream.Chunk
-	85, // 55: livekit.EncryptedPacketPayload.stream_trailer:type_name -> livekit.DataStream.Trailer
-	52, // 56: livekit.ActiveSpeakerUpdate.speakers:type_name -> livekit.SpeakerInfo
-	56, // 57: livekit.Transcription.segments:type_name -> livekit.TranscriptionSegment
-	61, // 58: livekit.RpcResponse.error:type_name -> livekit.RpcError
-	23, // 59: livekit.ServerInfo.edition:type_name -> livekit.ServerInfo.Edition
-	24, // 60: livekit.ClientInfo.sdk:type_name -> livekit.ClientInfo.SDK
-	25, // 61: livekit.ClientInfo.capabilities:type_name -> livekit.ClientInfo.Capability
-	66, // 62: livekit.ClientConfiguration.video:type_name -> livekit.VideoConfiguration
-	66, // 63: livekit.ClientConfiguration.screen:type_name -> livekit.VideoConfiguration
+	23, // 33: livekit.DataPacket.kind:type_name -> livekit.DataPacket.Kind
+	54, // 34: livekit.DataPacket.user:type_name -> livekit.UserPacket
+	52, // 35: livekit.DataPacket.speaker:type_name -> livekit.ActiveSpeakerUpdate
+	55, // 36: livekit.DataPacket.sip_dtmf:type_name -> livekit.SipDTMF
+	56, // 37: livekit.DataPacket.transcription:type_name -> livekit.Transcription
+	89, // 38: livekit.DataPacket.metrics:type_name -> livekit.MetricsBatch
+	58, // 39: livekit.DataPacket.chat_message:type_name -> livekit.ChatMessage
+	59, // 40: livekit.DataPacket.rpc_request:type_name -> livekit.RpcRequest
+	60, // 41: livekit.DataPacket.rpc_ack:type_name -> livekit.RpcAck
+	61, // 42: livekit.DataPacket.rpc_response:type_name -> livekit.RpcResponse
+	84, // 43: livekit.DataPacket.stream_header:type_name -> livekit.DataStream.Header
+	85, // 44: livekit.DataPacket.stream_chunk:type_name -> livekit.DataStream.Chunk
+	86, // 45: livekit.DataPacket.stream_trailer:type_name -> livekit.DataStream.Trailer
+	50, // 46: livekit.DataPacket.encrypted_packet:type_name -> livekit.EncryptedPacket
+	19, // 47: livekit.EncryptedPacket.encryption_type:type_name -> livekit.Encryption.Type
+	54, // 48: livekit.EncryptedPacketPayload.user:type_name -> livekit.UserPacket
+	58, // 49: livekit.EncryptedPacketPayload.chat_message:type_name -> livekit.ChatMessage
+	59, // 50: livekit.EncryptedPacketPayload.rpc_request:type_name -> livekit.RpcRequest
+	60, // 51: livekit.EncryptedPacketPayload.rpc_ack:type_name -> livekit.RpcAck
+	61, // 52: livekit.EncryptedPacketPayload.rpc_response:type_name -> livekit.RpcResponse
+	84, // 53: livekit.EncryptedPacketPayload.stream_header:type_name -> livekit.DataStream.Header
+	85, // 54: livekit.EncryptedPacketPayload.stream_chunk:type_name -> livekit.DataStream.Chunk
+	86, // 55: livekit.EncryptedPacketPayload.stream_trailer:type_name -> livekit.DataStream.Trailer
+	53, // 56: livekit.ActiveSpeakerUpdate.speakers:type_name -> livekit.SpeakerInfo
+	57, // 57: livekit.Transcription.segments:type_name -> livekit.TranscriptionSegment
+	62, // 58: livekit.RpcResponse.error:type_name -> livekit.RpcError
+	24, // 59: livekit.ServerInfo.edition:type_name -> livekit.ServerInfo.Edition
+	25, // 60: livekit.ClientInfo.sdk:type_name -> livekit.ClientInfo.SDK
+	26, // 61: livekit.ClientInfo.capabilities:type_name -> livekit.ClientInfo.Capability
+	67, // 62: livekit.ClientConfiguration.video:type_name -> livekit.VideoConfiguration
+	67, // 63: livekit.ClientConfiguration.screen:type_name -> livekit.VideoConfiguration
 	9,  // 64: livekit.ClientConfiguration.resume_connection:type_name -> livekit.ClientConfigSetting
-	67, // 65: livekit.ClientConfiguration.disabled_codecs:type_name -> livekit.DisabledCodecs
+	68, // 65: livekit.ClientConfiguration.disabled_codecs:type_name -> livekit.DisabledCodecs
 	9,  // 66: livekit.ClientConfiguration.force_relay:type_name -> livekit.ClientConfigSetting
 	9,  // 67: livekit.VideoConfiguration.hardware_encoder:type_name -> livekit.ClientConfigSetting
-	32, // 68: livekit.DisabledCodecs.codecs:type_name -> livekit.Codec
-	32, // 69: livekit.DisabledCodecs.publish:type_name -> livekit.Codec
-	89, // 70: livekit.RTPDrift.start_time:type_name -> google.protobuf.Timestamp
-	89, // 71: livekit.RTPDrift.end_time:type_name -> google.protobuf.Timestamp
-	89, // 72: livekit.RTPStats.start_time:type_name -> google.protobuf.Timestamp
-	89, // 73: livekit.RTPStats.end_time:type_name -> google.protobuf.Timestamp
-	80, // 74: livekit.RTPStats.gap_histogram:type_name -> livekit.RTPStats.GapHistogramEntry
-	89, // 75: livekit.RTPStats.last_pli:type_name -> google.protobuf.Timestamp
-	89, // 76: livekit.RTPStats.last_fir:type_name -> google.protobuf.Timestamp
-	89, // 77: livekit.RTPStats.last_key_frame:type_name -> google.protobuf.Timestamp
-	89, // 78: livekit.RTPStats.last_layer_lock_pli:type_name -> google.protobuf.Timestamp
-	68, // 79: livekit.RTPStats.packet_drift:type_name -> livekit.RTPDrift
-	68, // 80: livekit.RTPStats.ntp_report_drift:type_name -> livekit.RTPDrift
-	68, // 81: livekit.RTPStats.rebased_report_drift:type_name -> livekit.RTPDrift
-	68, // 82: livekit.RTPStats.received_report_drift:type_name -> livekit.RTPDrift
-	72, // 83: livekit.RTPForwarderState.rtp_munger:type_name -> livekit.RTPMungerState
-	73, // 84: livekit.RTPForwarderState.vp8_munger:type_name -> livekit.VP8MungerState
-	70, // 85: livekit.RTPForwarderState.sender_report_state:type_name -> livekit.RTCPSenderReportState
-	76, // 86: livekit.WebhookConfig.filter_params:type_name -> livekit.FilterParams
-	26, // 87: livekit.DataStream.TextHeader.operation_type:type_name -> livekit.DataStream.OperationType
-	18, // 88: livekit.DataStream.Header.encryption_type:type_name -> livekit.Encryption.Type
-	86, // 89: livekit.DataStream.Header.attributes:type_name -> livekit.DataStream.Header.AttributesEntry
-	81, // 90: livekit.DataStream.Header.text_header:type_name -> livekit.DataStream.TextHeader
-	82, // 91: livekit.DataStream.Header.byte_header:type_name -> livekit.DataStream.ByteHeader
-	27, // 92: livekit.DataStream.Header.compression:type_name -> livekit.DataStream.CompressionType
-	87, // 93: livekit.DataStream.Trailer.attributes:type_name -> livekit.DataStream.Trailer.AttributesEntry
+	33, // 68: livekit.DisabledCodecs.codecs:type_name -> livekit.Codec
+	33, // 69: livekit.DisabledCodecs.publish:type_name -> livekit.Codec
+	90, // 70: livekit.RTPDrift.start_time:type_name -> google.protobuf.Timestamp
+	90, // 71: livekit.RTPDrift.end_time:type_name -> google.protobuf.Timestamp
+	90, // 72: livekit.RTPStats.start_time:type_name -> google.protobuf.Timestamp
+	90, // 73: livekit.RTPStats.end_time:type_name -> google.protobuf.Timestamp
+	81, // 74: livekit.RTPStats.gap_histogram:type_name -> livekit.RTPStats.GapHistogramEntry
+	90, // 75: livekit.RTPStats.last_pli:type_name -> google.protobuf.Timestamp
+	90, // 76: livekit.RTPStats.last_fir:type_name -> google.protobuf.Timestamp
+	90, // 77: livekit.RTPStats.last_key_frame:type_name -> google.protobuf.Timestamp
+	90, // 78: livekit.RTPStats.last_layer_lock_pli:type_name -> google.protobuf.Timestamp
+	69, // 79: livekit.RTPStats.packet_drift:type_name -> livekit.RTPDrift
+	69, // 80: livekit.RTPStats.ntp_report_drift:type_name -> livekit.RTPDrift
+	69, // 81: livekit.RTPStats.rebased_report_drift:type_name -> livekit.RTPDrift
+	69, // 82: livekit.RTPStats.received_report_drift:type_name -> livekit.RTPDrift
+	73, // 83: livekit.RTPForwarderState.rtp_munger:type_name -> livekit.RTPMungerState
+	74, // 84: livekit.RTPForwarderState.vp8_munger:type_name -> livekit.VP8MungerState
+	71, // 85: livekit.RTPForwarderState.sender_report_state:type_name -> livekit.RTCPSenderReportState
+	77, // 86: livekit.WebhookConfig.filter_params:type_name -> livekit.FilterParams
+	27, // 87: livekit.DataStream.TextHeader.operation_type:type_name -> livekit.DataStream.OperationType
+	19, // 88: livekit.DataStream.Header.encryption_type:type_name -> livekit.Encryption.Type
+	87, // 89: livekit.DataStream.Header.attributes:type_name -> livekit.DataStream.Header.AttributesEntry
+	82, // 90: livekit.DataStream.Header.text_header:type_name -> livekit.DataStream.TextHeader
+	83, // 91: livekit.DataStream.Header.byte_header:type_name -> livekit.DataStream.ByteHeader
+	28, // 92: livekit.DataStream.Header.compression:type_name -> livekit.DataStream.CompressionType
+	88, // 93: livekit.DataStream.Trailer.attributes:type_name -> livekit.DataStream.Trailer.AttributesEntry
 	94, // [94:94] is the sub-list for method output_type
 	94, // [94:94] is the sub-list for method input_type
 	94, // [94:94] is the sub-list for extension type_name
@@ -7766,7 +7838,7 @@ func file_livekit_models_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_livekit_models_proto_rawDesc), len(file_livekit_models_proto_rawDesc)),
-			NumEnums:      28,
+			NumEnums:      29,
 			NumMessages:   60,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/livekit/livekit_webhook.pb.go
+++ b/livekit/livekit_webhook.pb.go
@@ -57,7 +57,9 @@ type WebhookEvent struct {
 	// timestamp in seconds
 	CreatedAt int64 `protobuf:"varint,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Deprecated: Marked as deprecated in livekit_webhook.proto.
-	NumDropped    int32 `protobuf:"varint,11,opt,name=num_dropped,json=numDropped,proto3" json:"num_dropped,omitempty"`
+	NumDropped int32 `protobuf:"varint,11,opt,name=num_dropped,json=numDropped,proto3" json:"num_dropped,omitempty"`
+	// set when event is room_finished
+	RoomEndReason RoomEndReason `protobuf:"varint,13,opt,name=room_end_reason,json=roomEndReason,proto3,enum=livekit.RoomEndReason" json:"room_end_reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -163,11 +165,18 @@ func (x *WebhookEvent) GetNumDropped() int32 {
 	return 0
 }
 
+func (x *WebhookEvent) GetRoomEndReason() RoomEndReason {
+	if x != nil {
+		return x.RoomEndReason
+	}
+	return RoomEndReason_ROOM_END_UNKNOWN
+}
+
 var File_livekit_webhook_proto protoreflect.FileDescriptor
 
 const file_livekit_webhook_proto_rawDesc = "" +
 	"\n" +
-	"\x15livekit_webhook.proto\x12\alivekit\x1a\x14livekit_models.proto\x1a\x14livekit_egress.proto\x1a\x15livekit_ingress.proto\x1a\x13livekit_agent.proto\"\x90\x03\n" +
+	"\x15livekit_webhook.proto\x12\alivekit\x1a\x14livekit_models.proto\x1a\x14livekit_egress.proto\x1a\x15livekit_ingress.proto\x1a\x13livekit_agent.proto\"\xd0\x03\n" +
 	"\fWebhookEvent\x12\x14\n" +
 	"\x05event\x18\x01 \x01(\tR\x05event\x12!\n" +
 	"\x04room\x18\x02 \x01(\v2\r.livekit.RoomR\x04room\x12:\n" +
@@ -182,7 +191,8 @@ const file_livekit_webhook_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\a \x01(\x03R\tcreatedAt\x12#\n" +
 	"\vnum_dropped\x18\v \x01(\x05B\x02\x18\x01R\n" +
-	"numDroppedBFZ#github.com/livekit/protocol/livekit\xaa\x02\rLiveKit.Proto\xea\x02\x0eLiveKit::Protob\x06proto3"
+	"numDropped\x12>\n" +
+	"\x0froom_end_reason\x18\r \x01(\x0e2\x16.livekit.RoomEndReasonR\rroomEndReasonBFZ#github.com/livekit/protocol/livekit\xaa\x02\rLiveKit.Proto\xea\x02\x0eLiveKit::Protob\x06proto3"
 
 var (
 	file_livekit_webhook_proto_rawDescOnce sync.Once
@@ -205,6 +215,7 @@ var file_livekit_webhook_proto_goTypes = []any{
 	(*IngressInfo)(nil),     // 4: livekit.IngressInfo
 	(*TrackInfo)(nil),       // 5: livekit.TrackInfo
 	(*Job)(nil),             // 6: livekit.Job
+	(RoomEndReason)(0),      // 7: livekit.RoomEndReason
 }
 var file_livekit_webhook_proto_depIdxs = []int32{
 	1, // 0: livekit.WebhookEvent.room:type_name -> livekit.Room
@@ -213,11 +224,12 @@ var file_livekit_webhook_proto_depIdxs = []int32{
 	4, // 3: livekit.WebhookEvent.ingress_info:type_name -> livekit.IngressInfo
 	5, // 4: livekit.WebhookEvent.track:type_name -> livekit.TrackInfo
 	6, // 5: livekit.WebhookEvent.job:type_name -> livekit.Job
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	7, // 6: livekit.WebhookEvent.room_end_reason:type_name -> livekit.RoomEndReason
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_livekit_webhook_proto_init() }

--- a/protobufs/livekit_analytics.proto
+++ b/protobufs/livekit_analytics.proto
@@ -184,8 +184,9 @@ message AnalyticsEvent {
   ReportInfo report = 33;
   APICallInfo api_call = 34;
   WebhookInfo webhook = 35;
+  RoomEndReason room_end_reason = 37;
 
-  // NEXT_ID: 37
+  // NEXT_ID: 38
 }
 
 message AnalyticsEvents {

--- a/protobufs/livekit_models.proto
+++ b/protobufs/livekit_models.proto
@@ -735,6 +735,21 @@ enum DisconnectReason {
   AGENT_ERROR = 16;
 }
 
+// why a room ended, reported on room-ended telemetry
+enum RoomEndReason {
+  ROOM_END_UNKNOWN = 0;
+  // RoomService.DeleteRoom was called
+  ROOM_END_API_DELETE = 1;
+  // the room sat empty past its empty or departure timeout
+  ROOM_END_IDLE_TIMEOUT = 2;
+  // the server instance is shutting down
+  ROOM_END_SERVER_SHUTDOWN = 3;
+  // the room was restarted or replaced elsewhere
+  ROOM_END_SUPERSEDED = 4;
+  // the room failed to finish opening
+  ROOM_END_OPEN_FAILED = 5;
+}
+
 message RTPDrift {
   google.protobuf.Timestamp start_time = 1;
   google.protobuf.Timestamp end_time = 2;

--- a/protobufs/livekit_webhook.proto
+++ b/protobufs/livekit_webhook.proto
@@ -55,5 +55,8 @@ message WebhookEvent {
 
   int32 num_dropped = 11 [deprecated=true];
 
-  // NEXT_ID: 13
+  // set when event is room_finished
+  RoomEndReason room_end_reason = 13;
+
+  // NEXT_ID: 14
 }


### PR DESCRIPTION
## What

Adds a `RoomEndReason` enum and reports it on room-ended telemetry:

- `AnalyticsEvent.room_end_reason` (field 37)
- `WebhookEvent.room_end_reason` (field 13)

```proto
enum RoomEndReason {
  ROOM_END_UNKNOWN = 0;
  ROOM_END_API_DELETE = 1;
  ROOM_END_IDLE_TIMEOUT = 2;
  ROOM_END_SERVER_SHUTDOWN = 3;
  ROOM_END_SUPERSEDED = 4;
  ROOM_END_OPEN_FAILED = 5;
}
```

## Why

Today the `ROOM_ENDED` event carries only the `Room` proto, so a room ended by an API `DeleteRoom` is indistinguishable from one that simply idled out. Participant events already solve this with `ParticipantInfo.disconnect_reason`; this gives room events the same treatment so room-end volume can be broken down by cause.

## Notes

- Purely additive — new enum, new optional fields. No existing field changed.
- Enum values are prefixed (`ROOM_END_*`) because proto3 enum values share the enclosing package namespace.
- Generated with the CI-pinned protoc 35.1, so the diff contains no version-stamp churn.

## Stack

1. **this PR** — protocol
2. livekit/livekit — consumes the enum, plumbs the reason to `RoomEnded`
3. livekit/cloud — plumbs the reason through roommanager + sweeper