### PR TITLE
utils/list: make mutations on unowned nodes no-ops

### DIFF
--- a/.changeset/list-unowned-node-noops.md
+++ b/.changeset/list-unowned-node-noops.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+`utils/list`: mutations involving a node the list does not own — removing or moving an unlinked node, inserting an already-linked node, or inserting relative to an unlinked mark — are now no-ops, as in `container/list`. Previously an unlinked node's zeroed hook made `Remove`/`MoveToFront`/`MoveToBack` clear the list's head and tail, silently stranding every remaining element, and re-inserting a linked node forked the list.

--- a/utils/list/list.go
+++ b/utils/list/list.go
@@ -32,9 +32,19 @@ type Hooked[T any] interface {
 	hookAccessor[T]
 }
 
+// List is an intrusive doubly-linked list. Mutations involving a node the list
+// does not own are no-ops, as in container/list. A node linked into a DIFFERENT
+// list is indistinguishable from a member without a per-node list pointer and
+// remains the caller's contract.
 type List[T any, P Hooked[T]] struct {
 	head P
 	tail P
+}
+
+// linked reports whether it is a member of this list. A zeroed hook is
+// ambiguous between "not linked" and "sole element"; the head check settles it.
+func (l *List[T, P]) linked(it P, h *Hook[T]) bool {
+	return h.prev != nil || h.next != nil || l.head == it
 }
 
 func (l *List[T, P]) Empty() bool {
@@ -58,10 +68,16 @@ func (l *List[T, P]) PushBack(it P) {
 }
 
 func (l *List[T, P]) InsertBefore(it, mark P) {
+	if !l.linked(mark, mark.getListHook()) {
+		return
+	}
 	l.insert(it, mark.getListHook().prev, mark)
 }
 
 func (l *List[T, P]) InsertAfter(it, mark P) {
+	if !l.linked(mark, mark.getListHook()) {
+		return
+	}
 	l.insert(it, mark, mark.getListHook().next)
 }
 
@@ -70,6 +86,9 @@ func (l *List[T, P]) MoveToFront(it P) {
 		return
 	}
 	h := it.getListHook()
+	if !l.linked(it, h) {
+		return
+	}
 	l.unlink(h)
 	l.link(it, h, nil, l.head)
 }
@@ -79,19 +98,29 @@ func (l *List[T, P]) MoveToBack(it P) {
 		return
 	}
 	h := it.getListHook()
+	if !l.linked(it, h) {
+		return
+	}
 	l.unlink(h)
 	l.link(it, h, l.tail, nil)
 }
 
 func (l *List[T, P]) Remove(it P) {
 	h := it.getListHook()
+	if !l.linked(it, h) {
+		return
+	}
 	l.unlink(h)
 	h.next = nil
 	h.prev = nil
 }
 
 func (l *List[T, P]) insert(it, prev, next P) {
-	l.link(it, it.getListHook(), prev, next)
+	h := it.getListHook()
+	if l.linked(it, h) {
+		return
+	}
+	l.link(it, h, prev, next)
 }
 
 func (l *List[T, P]) link(it P, h *Hook[T], prev, next P) {
@@ -110,6 +139,8 @@ func (l *List[T, P]) link(it P, h *Hook[T], prev, next P) {
 	}
 }
 
+// unlink requires a linked h: nil prev/next mean head/tail here, so a zeroed
+// hook would clear both.
 func (l *List[T, P]) unlink(h *Hook[T]) {
 	if h.prev != nil {
 		P(h.prev).getListHook().next = h.next

--- a/utils/list/list.go
+++ b/utils/list/list.go
@@ -68,17 +68,19 @@ func (l *List[T, P]) PushBack(it P) {
 }
 
 func (l *List[T, P]) InsertBefore(it, mark P) {
-	if !l.linked(mark, mark.getListHook()) {
+	mh := mark.getListHook()
+	if !l.linked(mark, mh) {
 		return
 	}
-	l.insert(it, mark.getListHook().prev, mark)
+	l.insert(it, mh.prev, mark)
 }
 
 func (l *List[T, P]) InsertAfter(it, mark P) {
-	if !l.linked(mark, mark.getListHook()) {
+	mh := mark.getListHook()
+	if !l.linked(mark, mh) {
 		return
 	}
-	l.insert(it, mark, mark.getListHook().next)
+	l.insert(it, mark, mh.next)
 }
 
 func (l *List[T, P]) MoveToFront(it P) {

--- a/utils/list/list_test.go
+++ b/utils/list/list_test.go
@@ -56,6 +56,70 @@ func TestTLPushFrontBackAndRemove(t *testing.T) {
 	require.Nil(t, l.Back())
 }
 
+// Every mutation on a node the list does not own is a no-op that leaves the
+// list intact.
+func TestTLUnownedNodeMutationsAreNoops(t *testing.T) {
+	var l testList
+	a := &testItem{value: "a"}
+	b := &testItem{value: "b"}
+	c := &testItem{value: "c"}
+	l.PushBack(a)
+	l.PushBack(b)
+	l.PushBack(c)
+
+	l.Remove(b)
+	l.Remove(b) // already removed
+	require.Equal(t, []string{"a", "c"}, collectValues(&l))
+
+	l.MoveToFront(b)
+	l.MoveToBack(b)
+	require.Equal(t, []string{"a", "c"}, collectValues(&l))
+	require.Nil(t, b.Next())
+	require.Nil(t, b.Prev())
+
+	d := &testItem{value: "d"} // never linked
+	l.Remove(d)
+	l.MoveToFront(d)
+	l.MoveToBack(d)
+	require.Equal(t, []string{"a", "c"}, collectValues(&l))
+
+	// An unlinked mark must not insert.
+	l.InsertBefore(d, b)
+	l.InsertAfter(d, b)
+	require.Equal(t, []string{"a", "c"}, collectValues(&l))
+	require.Nil(t, d.Next())
+	require.Nil(t, d.Prev())
+
+	// Sole-element lists still mutate normally: a zeroed hook is not proof of
+	// non-membership.
+	l.Remove(c)
+	require.Equal(t, []string{"a"}, collectValues(&l))
+	l.MoveToFront(a)
+	l.MoveToBack(a)
+	require.Equal(t, []string{"a"}, collectValues(&l))
+	l.Remove(a)
+	require.True(t, l.Empty())
+	require.Nil(t, l.Back())
+}
+
+// Inserting a node that is already linked is a no-op: reordering is MoveTo*'s
+// job, never a re-push.
+func TestTLInsertLinkedNodeIsNoop(t *testing.T) {
+	var l testList
+	a := &testItem{value: "a"}
+	b := &testItem{value: "b"}
+	l.PushBack(a)
+	l.PushBack(b)
+
+	l.PushFront(b)
+	l.PushBack(a)
+	l.InsertAfter(a, b)
+	l.InsertBefore(b, a)
+	require.Equal(t, []string{"a", "b"}, collectValues(&l))
+	require.Same(t, a, l.Front())
+	require.Same(t, b, l.Back())
+}
+
 func TestTLInsertAndMove(t *testing.T) {
 	var l testList
 	a := &testItem{value: "a"}


### PR DESCRIPTION
`Remove`, the moves, and the inserts corrupted the list when handed a node it did not own: `unlink` on a zeroed hook cleared `head` and `tail`, silently stranding every remaining element, and inserting an already-linked node forked the list. The failure surfaces arbitrarily far from the misuse — we hit it as a session actor whose remaining peers all kept their map entries and deadlines but became unreachable by every list walk, freezing its timer loop.

Every mutation is now guarded by a membership check and no-ops on an unowned node, matching `container/list`, where unowned-element mutations are no-ops. A zeroed hook alone is ambiguous between "not linked" and "sole element", so the check settles it against `head`. A node linked into a *different* list is indistinguishable without a per-node list pointer and remains the caller's contract (documented on `List`).

Tests cover the double-remove, unlinked moves, unlinked insert marks, re-insert of a linked node, and the sole-element edge; existing tests are unchanged.