### PR TITLE
observability/roomobs: regenerate for room simulation_index view

### DIFF
--- a/observability/roomobs/gen_reporter.go
+++ b/observability/roomobs/gen_reporter.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const Version_5CO3ESG = true
+const Version_D0OVKGG = true
 
 type KeyResolver interface {
 	Resolve(string)

--- a/observability/roomobs/gen_source.go
+++ b/observability/roomobs/gen_source.go
@@ -91,6 +91,7 @@ const (
 	// Deprecated: removed from schema; retained for compatibility with stored data.
 	RollupEndTimeIndex Rollup = "end_time_index"
 	// Deprecated: removed from schema; retained for compatibility with stored data.
-	RollupSessionIDIndex Rollup = "session_id_index"
-	RollupRoomSession    Rollup = "room_session"
+	RollupSessionIDIndex  Rollup = "session_id_index"
+	RollupRoomSession     Rollup = "room_session"
+	RollupSimulationIndex Rollup = "simulation_index"
 )


### PR DESCRIPTION
Generated code for the new `simulation_index` view added in livekit/cloud-observability#564.

Two additive changes:

- `RollupSimulationIndex Rollup = "simulation_index"` — new rollup constant.
- Schema version const bumped `Version_5CO3ESG` → `Version_D0OVKGG`.

No hand-written code touched; this is `mage generateschemas` output for `schema/room.yaml` only.

## Merge order

This should land **before** livekit/backend-common#1070 — that PR emits `const _ = roomobs.Version_D0OVKGG`, which does not compile until this is merged and its protocol dependency is bumped.

## Test plan

- `go build ./observability/...` passes.
- `go test ./observability/roomobs/...` passes.
