### PR TITLE
sdp: harden SDPFragment.Unmarshal against out-of-range accesses

### DIFF
--- a/.changeset/quiet-moons-guard.md
+++ b/.changeset/quiet-moons-guard.md
@@ -1,0 +1,6 @@
+---
+"github.com/livekit/protocol": patch
+"@livekit/protocol": patch
+---
+
+sdp: harden SDPFragment.Unmarshal against out-of-range accesses

--- a/sdp/sdp.go
+++ b/sdp/sdp.go
@@ -154,13 +154,13 @@ func ExtractStreamID(media *sdp.MediaDescription) (string, bool) {
 }
 
 func GetIP(sdp *sdp.SessionDescription) string {
-	if sdp.ConnectionInformation != nil && sdp.ConnectionInformation.NetworkType == "IN" {
-		return sdp.ConnectionInformation.Address.Address
+	if ci := sdp.ConnectionInformation; ci != nil && ci.NetworkType == "IN" && ci.Address != nil {
+		return ci.Address.Address
 	}
 
 	for _, media := range sdp.MediaDescriptions {
-		if media.ConnectionInformation != nil && media.ConnectionInformation.NetworkType == "IN" {
-			return media.ConnectionInformation.Address.Address
+		if ci := media.ConnectionInformation; ci != nil && ci.NetworkType == "IN" && ci.Address != nil {
+			return ci.Address.Address
 		}
 	}
 	return ""
@@ -417,6 +417,10 @@ func (s *SDPFragment) Unmarshal(frag string) error {
 		}
 
 		if line[0] == 'm' {
+			if len(line) < 3 || line[1] != '=' {
+				return errors.New("invalid media section")
+			}
+
 			if s.media != nil {
 				return errors.New("too many media sections")
 			}
@@ -431,7 +435,7 @@ func (s *SDPFragment) Unmarshal(frag string) error {
 			continue
 		}
 
-		if line[1] != '=' {
+		if len(line) < 2 || line[1] != '=' {
 			return errors.New("invalid attribute")
 		}
 
@@ -572,7 +576,7 @@ func (s *SDPFragment) ExtractICECredential() (string, string, error) {
 		}
 	}
 
-	if s.media != nil {
+	if s.media != nil && s.media.ice != nil {
 		if s.media.ice.ufrag != "" {
 			ufrags = append(ufrags, s.media.ice.ufrag)
 		}
@@ -670,31 +674,37 @@ func (s *SDPFragment) PatchICECredentialAndCandidatesIntoSDP(parsed *sdp.Session
 
 	if s.media != nil {
 		for _, md := range parsed.MediaDescriptions {
-			for idx, a := range md.Attributes {
-				switch a.Key {
-				case "ice-ufrag":
-					if s.media.ice.ufrag != "" {
-						md.Attributes[idx] = sdp.Attribute{
-							Key:   "ice-ufrag",
-							Value: s.media.ice.ufrag,
+			if s.media.ice != nil {
+				for idx, a := range md.Attributes {
+					switch a.Key {
+					case "ice-ufrag":
+						if s.media.ice.ufrag != "" {
+							md.Attributes[idx] = sdp.Attribute{
+								Key:   "ice-ufrag",
+								Value: s.media.ice.ufrag,
+							}
 						}
-					}
-				case "ice-pwd":
-					if s.media.ice.pwd != "" {
-						md.Attributes[idx] = sdp.Attribute{
-							Key:   "ice-pwd",
-							Value: s.media.ice.pwd,
+					case "ice-pwd":
+						if s.media.ice.pwd != "" {
+							md.Attributes[idx] = sdp.Attribute{
+								Key:   "ice-pwd",
+								Value: s.media.ice.pwd,
+							}
 						}
 					}
 				}
 			}
 
 			// clean out existing candidates and patch in new ones
-			for idx, a := range md.Attributes {
+			retained := md.Attributes[:0]
+			for _, a := range md.Attributes {
 				if a.IsICECandidate() || a.Key == sdp.AttrKeyEndOfCandidates {
-					md.Attributes = append(md.Attributes[:idx], md.Attributes[idx+1:]...)
+					continue
 				}
+
+				retained = append(retained, a)
 			}
+			md.Attributes = retained
 
 			for _, ic := range s.media.candidates {
 				md.Attributes = append(

--- a/sdp/sdp_test.go
+++ b/sdp/sdp_test.go
@@ -184,3 +184,57 @@ func TestSDPFragment(t *testing.T) {
 	expectedMarshalledSDPFragment3 := "a=group:BUNDLE 0 1\r\na=ice-options:trickle ice2\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=mid:0\r\na=ice-ufrag:ysXw\r\na=ice-pwd:vw5LmwG4y/e6dPP/zAP9Gp5k\r\na=candidate:1387637174 1 udp 2122260223 192.0.2.1 61764 typ host generation 0 ufrag EsAw network-id 1\r\na=candidate:3471623853 1 udp 2122194687 198.51.100.2 61765 typ host generation 0 ufrag EsAw network-id 2\r\na=candidate:473322822 1 tcp 1518280447 192.0.2.1 9 typ host tcptype active generation 0 ufrag EsAw network-id 1\r\na=candidate:2154773085 1 tcp 1518214911 198.51.100.2 9 typ host tcptype active generation 0 ufrag EsAw network-id 2\r\na=candidate:393455558 0 tcp 1518283007 [2401:4900:633c:959f:2037:680c:7c40:b3db] 9 typ host tcptype active\r\n"
 	require.Equal(t, expectedMarshalledSDPFragment3, marshalledSDPFragment3)
 }
+
+func TestSDPFragmentUnmarshalMalformed(t *testing.T) {
+	// malformed fragments should error out, not panic
+	malformed := []string{
+		"",
+		"m",
+		"a",
+		"m\r\n",
+		"a\r\n",
+		"m=",
+		"a=",
+		"mx=audio 9 UDP/TLS/RTP/SAVPF 111",
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\na",
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\nax\r\n",
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=mid:0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\n",
+		"a=ice-lite\r\na=ice-ufrag:ysXw\r\n",
+	}
+	for _, frag := range malformed {
+		sdpFragment := &SDPFragment{}
+		require.Error(t, sdpFragment.Unmarshal(frag), "fragment: %q", frag)
+	}
+}
+
+func FuzzSDPFragmentUnmarshal(f *testing.F) {
+	f.Add("a=group:BUNDLE 0\r\na=ice-lite\r\na=ice-options:trickle ice2\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=mid:0\r\na=ice-ufrag:ysXw\r\na=ice-pwd:vw5LmwG4y/e6dPP/zAP9Gp5k\r\na=candidate:1387637174 1 udp 2122260223 192.0.2.1 61764 typ host\r\na=end-of-candidates\r\n")
+	f.Add("m=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=mid:0\r\n")
+	f.Add("m")
+	f.Add("a")
+	f.Add("a=")
+	f.Add("m=\na")
+
+	f.Fuzz(func(t *testing.T, frag string) {
+		sdpFragment := &SDPFragment{}
+		if err := sdpFragment.Unmarshal(frag); err != nil {
+			return
+		}
+
+		// accessors and marshalling of anything that parsed should be safe too
+		sdpFragment.Mid()
+		sdpFragment.Candidates()
+		sdpFragment.ExtractICECredential()
+		marshalled, err := sdpFragment.Marshal()
+		if err != nil {
+			t.Fatalf("marshal of parsed fragment %q failed: %v", frag, err)
+		}
+
+		// marshalling a parsed fragment should produce something that parses back the same
+		reparsed := &SDPFragment{}
+		if err := reparsed.Unmarshal(marshalled); err != nil {
+			t.Fatalf("re-unmarshal of %q (from %q) failed: %v", marshalled, frag, err)
+		}
+		require.Equal(t, sdpFragment, reparsed, "fragment: %q", frag)
+	})
+}


### PR DESCRIPTION
`SDPFragment.Unmarshal` indexed into a line knowing only that it was non-empty:

- `line[2:]` on an `m` line — a bare `"m"` line panicked with `slice bounds out of range [2:1]`
- `line[1]` on an `a` line — a bare `"a"` line panicked

Both are reachable from a client-supplied WHIP Trickle ICE fragment. Both are now length-checked before indexing. An `m=` line is additionally required to carry a value, since `Marshal` drops the `m=` line when `info == ""` and an empty media info therefore broke Marshal/Unmarshal symmetry.

The rest of the function was already safe — `delimIndex` comes from `strings.Index`, and the `bundleIDs[1]` access is behind a `len > 1` check.

### Also in the file

- **`GetIP` — nil deref.** `ConnectionInformation.Address` is a `*sdp.Address` and can be nil for a `c=` line the parser accepted without an address; only `ConnectionInformation` itself was checked.
- **`PatchICECredentialAndCandidatesIntoSDP` — mutation while ranging.** The candidate cleanup did `md.Attributes = append(md.Attributes[:idx], md.Attributes[idx+1:]...)` while ranging over the same slice by index. No panic (the reslices stay within cap), but `range` captured the original length, so after the first removal every index is stale: consecutive candidates get skipped and stale trailing elements get re-read. Real consequence is old candidates surviving an ICE restart. Replaced with an in-place filter.
- **`s.media.ice` nil derefs** in `ExtractICECredential` and `PatchICECredentialAndCandidatesIntoSDP`, where a sibling check for it already existed. Defensive — every current construction path sets `ice`.

Left alone: `ExtractFingerprint`, `ExtractStreamID`, `GetMediaStreamTrack`, `GetSimulcastRids`, `GetBundleMid` — their slice accesses are already behind explicit length checks.

One deliberate non-change: `"a=group:BUNDLE"` with no mids still parses without error (the bundle-mid check is skipped when there is only one token). That is a validation gap rather than a memory-safety one, and it matches `GetBundleMid`'s lenient behavior.

### Tests

- `TestSDPFragmentUnmarshalMalformed` — table of truncated/malformed fragments that must error rather than panic.
- `FuzzSDPFragmentUnmarshal` — fuzzes `Unmarshal`, then exercises `Mid`/`Candidates`/`ExtractICECredential`/`Marshal` on anything that parsed, and asserts the marshalled output re-parses to an equal fragment.

`go test ./sdp/` passes; 30s / 12.2M fuzz execs clean. The two panics were confirmed against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)