### PR TITLE
hwstats: build on darwin without cgo

### DIFF
--- a/.changeset/curly-poems-build.md
+++ b/.changeset/curly-poems-build.md
@@ -1,0 +1,6 @@
+---
+"github.com/livekit/protocol": patch
+"@livekit/protocol": patch
+---
+
+Build utils/hwstats on darwin without cgo

--- a/utils/hwstats/cpu_all.go
+++ b/utils/hwstats/cpu_all.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !(darwin && !cgo)
+
 package hwstats
 
 import (

--- a/utils/hwstats/cpu_darwin.go
+++ b/utils/hwstats/cpu_darwin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build darwin
+//go:build darwin && cgo
 
 package hwstats
 

--- a/utils/hwstats/cpu_null.go
+++ b/utils/hwstats/cpu_null.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !(linux || darwin)
+//go:build !linux && !(darwin && cgo)
 
 package hwstats
 


### PR DESCRIPTION
## Problem

`go-osstat` only implements its darwin CPU counters behind cgo (its `cpu_darwin_nocgo.go` is a stub), so `CGO_ENABLED=0 GOOS=darwin go build ./...` fails in `utils/hwstats`:

```
# github.com/livekit/protocol/utils/hwstats
utils/hwstats/cpu_all.go:24:12: undefined: cpu.Stats
utils/hwstats/cpu_all.go:28:20: undefined: cpu.Get
utils/hwstats/cpu_all.go:39:19: undefined: cpu.Get
```

This blocks cross-compiling darwin binaries from a linux host, where `CGO_ENABLED=0` is required. (Context: an open-source project embedding livekit-server and cross-compiling six OS/arch targets from one linux runner; previously discussed in #659 / #272.)

## Change

Three build-tag edits, no new code:

| file | before | after |
| --- | --- | --- |
| `cpu_all.go` | *(none)* | `!(darwin && !cgo)` |
| `cpu_darwin.go` | `darwin` | `darwin && cgo` |
| `cpu_null.go` | `!(linux \|\| darwin)` | `!linux && !(darwin && cgo)` |

Restrict the go-osstat monitor and the darwin platform monitor to cgo builds, and widen the **existing** null monitor to cover darwin without cgo. That mirrors what the null monitor already does on other unsupported platforms: CPU stats degrade to a no-op and capacity management is disabled, nothing else changes. Builds with cgo enabled are unaffected. A changeset is included.

## Verification

- `CGO_ENABLED=0 go build ./...` for `darwin/arm64`, `darwin/amd64`, `linux`, `windows`, `freebsd` — pass
- `CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build ./...` — pass (unchanged path)
- `go vet ./utils/hwstats/...` in both cgo modes — clean
- `go test ./utils/hwstats/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)