### PR TITLE
hwstats: keep cgroup usage when the cgroup has no memory limit

### DIFF
--- a/.changeset/hwstats-cgroup-unlimited-usage.md
+++ b/.changeset/hwstats-cgroup-unlimited-usage.md
@@ -1,5 +1,0 @@
----
-"github.com/livekit/protocol": patch
----
-
-hwstats: report the cgroup's own memory usage when the cgroup has no memory limit, instead of node-wide usage. For containers without a memory limit, memory used over memory total now describes the container rather than the node.

--- a/.changeset/hwstats-cgroup-unlimited-usage.md
+++ b/.changeset/hwstats-cgroup-unlimited-usage.md
@@ -1,0 +1,5 @@
+---
+"github.com/livekit/protocol": patch
+---
+
+hwstats: report the cgroup's own memory usage when the cgroup has no memory limit, instead of node-wide usage. For containers without a memory limit, memory used over memory total now describes the container rather than the node.

--- a/utils/hwstats/memory_linux.go
+++ b/utils/hwstats/memory_linux.go
@@ -26,16 +26,19 @@ import (
 	"github.com/livekit/protocol/logger"
 )
 
-const (
-	memUsagePathV1      = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
-	memLimitPathV1      = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-	memStatPathV1       = "/sys/fs/cgroup/memory/memory.stat"
-	totalInactiveFileV1 = "total_inactive_file"
+var (
+	memUsagePathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+	memLimitPathV1 = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	memStatPathV1  = "/sys/fs/cgroup/memory/memory.stat"
 
 	memCurrentPathV2 = "/sys/fs/cgroup/memory.current"
 	memMaxPathV2     = "/sys/fs/cgroup/memory.max"
 	memStatPathV2    = "/sys/fs/cgroup/memory.stat"
-	inactiveFileV2   = "inactive_file"
+)
+
+const (
+	totalInactiveFileV1 = "total_inactive_file"
+	inactiveFileV2      = "inactive_file"
 )
 
 type memInfoGetter interface {
@@ -114,12 +117,12 @@ func (cg *memInfoGetterV1) getMemory() (uint64, uint64, error) {
 
 	// fallback if limit from cgroup is more than physical available memory
 	// when limit is not set explicitly, it could be very high
-	usage1, total1, err := cg.osStat.getMemory()
+	_, total1, err := cg.osStat.getMemory()
 	if err != nil {
 		return 0, 0, err
 	}
 	if total > total1 {
-		return usage1, total1, nil
+		return usage, total1, nil
 	}
 
 	return usage, total, nil
@@ -150,7 +153,7 @@ func (cg *memInfoGetterV2) getMemory() (uint64, uint64, error) {
 	total, err := readValueFromFile(memMaxPathV2)
 	if err != nil {
 		// when memory limit not set, it has the string "max"
-		usage, total, err = cg.osStat.getMemory()
+		_, total, err = cg.osStat.getMemory()
 		if err != nil {
 			return 0, 0, err
 		}

--- a/utils/hwstats/memory_linux_test.go
+++ b/utils/hwstats/memory_linux_test.go
@@ -1,0 +1,108 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package hwstats
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCgroupCharged      = uint64(3 << 30)
+	testCgroupInactiveFile = uint64(1 << 30)
+	testCgroupWorkingSet   = testCgroupCharged - testCgroupInactiveFile
+)
+
+// writeCgroupFiles points the given path variables at freshly written files for the duration of the test.
+func writeCgroupFiles(t *testing.T, usagePath, limitPath, statPath *string, limit, inactiveFileKey string) {
+	dir := t.TempDir()
+	files := map[*string]string{
+		usagePath: strconv.FormatUint(testCgroupCharged, 10) + "\n",
+		limitPath: limit + "\n",
+		statPath:  "anon 1024\n" + inactiveFileKey + " " + strconv.FormatUint(testCgroupInactiveFile, 10) + "\n",
+	}
+	for ptr, content := range files {
+		path := filepath.Join(dir, filepath.Base(*ptr))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+		orig := *ptr
+		*ptr = path
+		t.Cleanup(func() { *ptr = orig })
+	}
+}
+
+func nodeMemory(t *testing.T) uint64 {
+	osStat, err := newOSStatMemoryGetter()
+	require.NoError(t, err)
+	_, total, err := osStat.getMemory()
+	require.NoError(t, err)
+	return total
+}
+
+func TestMemInfoGetterV2(t *testing.T) {
+	nodeTotal := nodeMemory(t)
+	osStat, err := newOSStatMemoryGetter()
+	require.NoError(t, err)
+	cg := newMemInfoGetterV2(osStat)
+
+	t.Run("limit set", func(t *testing.T) {
+		// below physical memory so the cgroup limit is reported as is
+		limit := nodeTotal / 2
+		writeCgroupFiles(t, &memCurrentPathV2, &memMaxPathV2, &memStatPathV2, strconv.FormatUint(limit, 10), inactiveFileV2)
+		usage, total, err := cg.getMemory()
+		require.NoError(t, err)
+		require.Equal(t, testCgroupWorkingSet, usage)
+		require.Equal(t, limit, total)
+	})
+
+	t.Run("unlimited keeps cgroup usage", func(t *testing.T) {
+		writeCgroupFiles(t, &memCurrentPathV2, &memMaxPathV2, &memStatPathV2, "max", inactiveFileV2)
+		usage, total, err := cg.getMemory()
+		require.NoError(t, err)
+		require.Equal(t, testCgroupWorkingSet, usage)
+		require.Equal(t, nodeTotal, total)
+	})
+}
+
+func TestMemInfoGetterV1(t *testing.T) {
+	nodeTotal := nodeMemory(t)
+	osStat, err := newOSStatMemoryGetter()
+	require.NoError(t, err)
+	cg := newMemInfoGetterV1(osStat)
+
+	t.Run("limit set", func(t *testing.T) {
+		// below physical memory so the cgroup limit is reported as is
+		limit := nodeTotal / 2
+		writeCgroupFiles(t, &memUsagePathV1, &memLimitPathV1, &memStatPathV1, strconv.FormatUint(limit, 10), totalInactiveFileV1)
+		usage, total, err := cg.getMemory()
+		require.NoError(t, err)
+		require.Equal(t, testCgroupWorkingSet, usage)
+		require.Equal(t, limit, total)
+	})
+
+	t.Run("limit above physical keeps cgroup usage", func(t *testing.T) {
+		// cgroup v1 reports an unlimited cgroup as a limit far above physical memory
+		writeCgroupFiles(t, &memUsagePathV1, &memLimitPathV1, &memStatPathV1, "9223372036854771712", totalInactiveFileV1)
+		usage, total, err := cg.getMemory()
+		require.NoError(t, err)
+		require.Equal(t, testCgroupWorkingSet, usage)
+		require.Equal(t, nodeTotal, total)
+	})
+}


### PR DESCRIPTION
## Summary

`hwstats.MemoryStats.GetMemory` returned node-wide usage for containers without a memory limit. It now returns the container's own cgroup working set in that case, and takes only the total from the node.

## Problem

`utils/hwstats/memory_linux.go` reads the container cgroup, but falls back to `/proc/meminfo` when the cgroup has no usable limit:

- cgroup v2: `memory.max` contains the string `max` when no limit is set, so the parse fails and the fallback runs.
- cgroup v1: an unlimited cgroup reports a limit far above physical memory, which triggers the same fallback.

In both branches the fallback replaced **usage** as well as total. Usage then described the whole node. Any consumer comparing usage against a per-container budget saw its neighbours' memory.

Production impact (egress, 2026-09-07, oashburn1b): the egress container has requests only, no memory limit. Once several egress pods shared 64 vCPU private-pool nodes, every pod read 23 to 34 GB "used", exceeded its `max_memory: 23` and killed its largest handler as OOM (15 kills of tiny handlers), and idle pods rejected every admission. Stopgap in livekit/cloud-config#18026 switches that cluster to per-process RSS until this lands.

## Fix

Two lines: keep the cgroup usage in both fallback branches, substitute only the total.

```go
// v1
_, total1, err := cg.osStat.getMemory()
if total > total1 { return usage, total1, nil }

// v2
_, total, err = cg.osStat.getMemory()
```

Cgroups with a real limit that fits in physical memory are unchanged. The no-cgroup fallback (`osStatMemoryGetter` used directly) is unchanged.

## Test

`memory_linux_test.go` (linux build tag) points the readers at temp files via the path variables, which are now package `var`s instead of `const`s for that purpose. It writes a cgroup charged 3 GiB with 1 GiB inactive file and asserts usage is 2 GiB and total is the node's physical memory for `memory.max = max` and for the v1 sentinel limit. Both cases fail on `main`. The "limit set" cases use half the node total so they hold on small runners.

## Consumers

- **egress** discards the total and compares usage to its own config; this is the fix it needs.
- **livekit-server** reports used and total in `NodeStats`, and cloud derives `memory_load` from them. cloud-media runs with `limits.memory == requests.memory`, so neither fallback branch executes and its values are unchanged. Self-hosted servers without a memory limit will see `memory_load` become container used over node total instead of node used over node total, which is the intended meaning. Noted in the changeset.

## Follow-up

A separate PR will dedupe the v1/v2 reader logic behind the tests added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)