### PR TITLE
utils: move Promise and DeepCopy to dependency-free subpackages

### DIFF
--- a/utils/deepcopy.go
+++ b/utils/deepcopy.go
@@ -14,61 +14,6 @@
 
 package utils
 
-import (
-	"reflect"
-)
+import "github.com/livekit/protocol/utils/deepcopy"
 
-func DeepCopy[T any](v T) T {
-	return deepCopy(reflect.ValueOf(v)).Interface().(T)
-}
-
-func deepCopy(v reflect.Value) reflect.Value {
-	switch v.Type().Kind() {
-	case reflect.Array:
-		c := reflect.New(v.Type()).Elem()
-		for i := range v.Len() {
-			c.Index(i).Set(deepCopy(v.Index(i)))
-		}
-		return c
-
-	case reflect.Map:
-		if v.IsNil() {
-			return v
-		}
-		c := reflect.MakeMap(v.Type())
-		for mr := v.MapRange(); mr.Next(); {
-			c.SetMapIndex(deepCopy(mr.Key()), deepCopy(mr.Value()))
-		}
-		return c
-
-	case reflect.Pointer:
-		if v.IsNil() {
-			return v
-		}
-		c := reflect.New(v.Type().Elem())
-		c.Elem().Set(deepCopy(v.Elem()))
-		return c
-
-	case reflect.Slice:
-		if v.IsNil() {
-			return v
-		}
-		c := reflect.MakeSlice(v.Type(), v.Len(), v.Cap())
-		for i := range v.Len() {
-			c.Index(i).Set(deepCopy(v.Index(i)))
-		}
-		return c
-
-	case reflect.Struct:
-		c := reflect.New(v.Type()).Elem()
-		for i := range v.NumField() {
-			if c.Field(i).CanSet() {
-				c.Field(i).Set(deepCopy(v.Field(i)))
-			}
-		}
-		return c
-
-	default: // Bool, Chan, Complex128, Complex64, Float32, Float64, Func, Int, Int16, Int32, Int64, Int8, Interface, String, Uint, Uint16, Uint32, Uint64, Uint8, Uintptr, UnsafePointer
-		return v
-	}
-}
+func DeepCopy[T any](v T) T { return deepcopy.Copy(v) }

--- a/utils/deepcopy/deepcopy.go
+++ b/utils/deepcopy/deepcopy.go
@@ -1,0 +1,76 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deepcopy carries no dependencies beyond the standard library, so a
+// package that needs only a deep copy does not inherit the rest of utils.
+package deepcopy
+
+import (
+	"reflect"
+)
+
+func Copy[T any](v T) T {
+	return copyValue(reflect.ValueOf(v)).Interface().(T)
+}
+
+func copyValue(v reflect.Value) reflect.Value {
+	switch v.Type().Kind() {
+	case reflect.Array:
+		c := reflect.New(v.Type()).Elem()
+		for i := range v.Len() {
+			c.Index(i).Set(copyValue(v.Index(i)))
+		}
+		return c
+
+	case reflect.Map:
+		if v.IsNil() {
+			return v
+		}
+		c := reflect.MakeMap(v.Type())
+		for mr := v.MapRange(); mr.Next(); {
+			c.SetMapIndex(copyValue(mr.Key()), copyValue(mr.Value()))
+		}
+		return c
+
+	case reflect.Pointer:
+		if v.IsNil() {
+			return v
+		}
+		c := reflect.New(v.Type().Elem())
+		c.Elem().Set(copyValue(v.Elem()))
+		return c
+
+	case reflect.Slice:
+		if v.IsNil() {
+			return v
+		}
+		c := reflect.MakeSlice(v.Type(), v.Len(), v.Cap())
+		for i := range v.Len() {
+			c.Index(i).Set(copyValue(v.Index(i)))
+		}
+		return c
+
+	case reflect.Struct:
+		c := reflect.New(v.Type()).Elem()
+		for i := range v.NumField() {
+			if c.Field(i).CanSet() {
+				c.Field(i).Set(copyValue(v.Field(i)))
+			}
+		}
+		return c
+
+	default: // Bool, Chan, Complex128, Complex64, Float32, Float64, Func, Int, Int16, Int32, Int64, Int8, Interface, String, Uint, Uint16, Uint32, Uint64, Uint8, Uintptr, UnsafePointer
+		return v
+	}
+}

--- a/utils/deepcopy/deepcopy_test.go
+++ b/utils/deepcopy/deepcopy_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package deepcopy
 
 import (
 	"testing"
@@ -31,7 +31,7 @@ type copyTestType struct {
 	vunexported    bool //nolint:unused // tests deep copy of unexported fields
 }
 
-func TestDeepCopy(t *testing.T) {
+func TestCopy(t *testing.T) {
 	v := &copyTestType{
 		Vbool:  true,
 		Varray: [3]int{0, 1, 2},
@@ -42,5 +42,5 @@ func TestDeepCopy(t *testing.T) {
 		},
 	}
 
-	require.EqualValues(t, v, DeepCopy(v))
+	require.EqualValues(t, v, Copy(v))
 }

--- a/utils/promise.go
+++ b/utils/promise.go
@@ -2,104 +2,22 @@ package utils
 
 import (
 	"context"
-	"sync"
+
+	"github.com/livekit/protocol/utils/promise"
 )
 
-var closedPromiseChan = make(chan struct{})
+// Promise must stay an alias rather than a defined type: a promise built under
+// either spelling has to satisfy an interface written against the other.
+type Promise[T any] = promise.Promise[T]
 
-func init() {
-	close(closedPromiseChan)
-}
+func NewPromise[T any]() *Promise[T] { return promise.New[T]() }
 
-type Promise[T any] struct {
-	mu     sync.Mutex
-	done   chan struct{}
-	thens  []func(T, error)
-	Result T
-	Err    error
-}
-
-func NewPromise[T any]() *Promise[T] {
-	return &Promise[T]{}
-}
-
-func GoPromise[T any](f func() (T, error)) *Promise[T] {
-	p := NewPromise[T]()
-	go func() { p.Resolve(f()) }()
-	return p
-}
+func GoPromise[T any](f func() (T, error)) *Promise[T] { return promise.Go(f) }
 
 func NewResolvedPromise[T any](result T, err error) *Promise[T] {
-	return &Promise[T]{
-		Result: result,
-		Err:    err,
-		done:   closedPromiseChan,
-	}
-}
-
-func (p *Promise[T]) Resolve(result T, err error) {
-	p.mu.Lock()
-
-	if p.done == closedPromiseChan {
-		p.mu.Unlock()
-		return
-	}
-
-	p.Result = result
-	p.Err = err
-
-	if p.done != nil {
-		close(p.done)
-	}
-	p.done = closedPromiseChan
-
-	thens := p.thens
-	p.thens = nil
-	p.mu.Unlock()
-
-	// invoked unlocked so a callback can re-enter the promise
-	for _, f := range thens {
-		f(result, err)
-	}
-}
-
-// Then registers f to run when p resolves, on the goroutine that calls Resolve. If p is
-// already resolved, f runs inline on the calling goroutine.
-func (p *Promise[T]) Then(f func(T, error)) {
-	p.mu.Lock()
-
-	if p.done == closedPromiseChan {
-		result, err := p.Result, p.Err
-		p.mu.Unlock()
-		f(result, err)
-		return
-	}
-
-	p.thens = append(p.thens, f)
-	p.mu.Unlock()
-}
-
-func (p *Promise[T]) Done() <-chan struct{} {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.done == nil {
-		p.done = make(chan struct{})
-	}
-	return p.done
-}
-
-func (p *Promise[T]) Resolved() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.done == closedPromiseChan
+	return promise.NewResolved(result, err)
 }
 
 func AwaitPromise[T any](ctx context.Context, p *Promise[T]) (T, error) {
-	select {
-	case <-ctx.Done():
-		var v T
-		return v, ctx.Err()
-	case <-p.Done():
-		return p.Result, p.Err
-	}
+	return promise.Await(ctx, p)
 }

--- a/utils/promise/promise.go
+++ b/utils/promise/promise.go
@@ -1,0 +1,109 @@
+// Package promise carries no dependencies beyond the standard library, so a
+// package that needs only a promise does not inherit the rest of utils.
+package promise
+
+import (
+	"context"
+	"sync"
+)
+
+var closedPromiseChan = make(chan struct{})
+
+func init() {
+	close(closedPromiseChan)
+}
+
+type Promise[T any] struct {
+	mu     sync.Mutex
+	done   chan struct{}
+	thens  []func(T, error)
+	Result T
+	Err    error
+}
+
+func New[T any]() *Promise[T] {
+	return &Promise[T]{}
+}
+
+func Go[T any](f func() (T, error)) *Promise[T] {
+	p := New[T]()
+	go func() { p.Resolve(f()) }()
+	return p
+}
+
+// NewResolved is spelled apart from the Resolved method, which reports whether a
+// promise has settled.
+func NewResolved[T any](result T, err error) *Promise[T] {
+	return &Promise[T]{
+		Result: result,
+		Err:    err,
+		done:   closedPromiseChan,
+	}
+}
+
+func (p *Promise[T]) Resolve(result T, err error) {
+	p.mu.Lock()
+
+	if p.done == closedPromiseChan {
+		p.mu.Unlock()
+		return
+	}
+
+	p.Result = result
+	p.Err = err
+
+	if p.done != nil {
+		close(p.done)
+	}
+	p.done = closedPromiseChan
+
+	thens := p.thens
+	p.thens = nil
+	p.mu.Unlock()
+
+	// invoked unlocked so a callback can re-enter the promise
+	for _, f := range thens {
+		f(result, err)
+	}
+}
+
+// Then registers f to run when p resolves, on the goroutine that calls Resolve. If p is
+// already resolved, f runs inline on the calling goroutine.
+func (p *Promise[T]) Then(f func(T, error)) {
+	p.mu.Lock()
+
+	if p.done == closedPromiseChan {
+		result, err := p.Result, p.Err
+		p.mu.Unlock()
+		f(result, err)
+		return
+	}
+
+	p.thens = append(p.thens, f)
+	p.mu.Unlock()
+}
+
+func (p *Promise[T]) Done() <-chan struct{} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.done == nil {
+		p.done = make(chan struct{})
+	}
+	return p.done
+}
+
+func (p *Promise[T]) Resolved() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.done == closedPromiseChan
+}
+
+func Await[T any](ctx context.Context, p *Promise[T]) (T, error) {
+	select {
+	case <-ctx.Done():
+		var v T
+		return v, ctx.Err()
+	case <-p.Done():
+		return p.Result, p.Err
+	}
+}

--- a/utils/promise/promise_test.go
+++ b/utils/promise/promise_test.go
@@ -1,0 +1,163 @@
+package promise
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromise(t *testing.T) {
+	t.Run("zero value is usable", func(t *testing.T) {
+		var p Promise[bool]
+
+		require.False(t, p.Resolved())
+		done := p.Done()
+		select {
+		case <-done:
+			require.FailNow(t, "unresolved done channel should block")
+		default:
+		}
+
+		p.Resolve(true, nil)
+
+		require.True(t, p.Resolved())
+		select {
+		case <-done:
+		default:
+			require.FailNow(t, "resolved done channel should not block")
+		}
+
+		require.True(t, p.Result)
+	})
+
+	t.Run("promise cannot be resolved twice", func(t *testing.T) {
+		p := New[bool]()
+		p.Resolve(false, errors.New("fail"))
+		p.Resolve(true, nil)
+
+		require.False(t, p.Result)
+		require.Error(t, p.Err)
+	})
+}
+
+func TestPromiseThen(t *testing.T) {
+	t.Run("callback runs on the resolving goroutine", func(t *testing.T) {
+		p := New[int]()
+
+		var (
+			gotResult int
+			gotErr    error
+			called    bool
+		)
+		p.Then(func(result int, err error) {
+			gotResult, gotErr, called = result, err, true
+		})
+		require.False(t, called, "callback should not run before resolution")
+
+		expErr := errors.New("fail")
+		var calledBeforeResolveReturned bool
+		resolved := make(chan struct{})
+		go func() {
+			defer close(resolved)
+			p.Resolve(7, expErr)
+			calledBeforeResolveReturned = called
+		}()
+
+		<-resolved
+		require.True(t, calledBeforeResolveReturned, "callback should have run before Resolve returned")
+		require.Equal(t, 7, gotResult)
+		require.Equal(t, expErr, gotErr)
+	})
+
+	t.Run("callback registered after resolution runs inline", func(t *testing.T) {
+		p := New[int]()
+		p.Resolve(7, nil)
+
+		var called bool
+		p.Then(func(result int, err error) {
+			called = true
+			require.Equal(t, 7, result)
+			require.NoError(t, err)
+		})
+		require.True(t, called, "callback should run before Then returned")
+	})
+
+	t.Run("callbacks run in registration order", func(t *testing.T) {
+		p := New[int]()
+
+		var order []int
+		for i := range 3 {
+			p.Then(func(int, error) { order = append(order, i) })
+		}
+		p.Resolve(0, nil)
+
+		require.Equal(t, []int{0, 1, 2}, order)
+	})
+
+	t.Run("callbacks run once when resolved twice", func(t *testing.T) {
+		p := New[int]()
+
+		var calls int
+		p.Then(func(int, error) { calls++ })
+
+		p.Resolve(1, nil)
+		p.Resolve(2, nil)
+
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("zero value and resolved promise accept callbacks", func(t *testing.T) {
+		var zero Promise[int]
+		var zeroCalled bool
+		zero.Then(func(result int, err error) { zeroCalled = true })
+		require.False(t, zeroCalled)
+		zero.Resolve(7, nil)
+		require.True(t, zeroCalled)
+
+		var resolvedCalled bool
+		NewResolved(7, nil).Then(func(result int, err error) {
+			resolvedCalled = true
+			require.Equal(t, 7, result)
+		})
+		require.True(t, resolvedCalled)
+	})
+
+	t.Run("callback can re-enter the promise", func(t *testing.T) {
+		p := New[int]()
+
+		var (
+			resolvedDuringCallback bool
+			awaitResult            int
+			awaitErr               error
+			nested                 bool
+		)
+		p.Then(func(int, error) {
+			resolvedDuringCallback = p.Resolved()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			awaitResult, awaitErr = Await(ctx, p)
+
+			p.Then(func(int, error) { nested = true })
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			p.Resolve(7, nil)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "re-entrant callback deadlocked")
+		}
+		require.True(t, resolvedDuringCallback)
+		require.Equal(t, 7, awaitResult)
+		require.NoError(t, awaitErr)
+		require.True(t, nested, "callback registered during dispatch should run inline")
+	})
+}

--- a/utils/promise_test.go
+++ b/utils/promise_test.go
@@ -1,163 +1,23 @@
 package utils
 
 import (
-	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/utils/promise"
 )
 
-func TestPromise(t *testing.T) {
-	t.Run("zero value is usable", func(t *testing.T) {
-		var p Promise[bool]
+// A defined type here would compile but break every caller that mixes the two
+// spellings, which no test of behaviour would catch.
+var _ *Promise[int] = (*promise.Promise[int])(nil)
 
-		require.False(t, p.Resolved())
-		done := p.Done()
-		select {
-		case <-done:
-			require.FailNow(t, "unresolved done channel should block")
-		default:
-		}
+func TestPromiseAlias(t *testing.T) {
+	p := NewPromise[int]()
+	promise.Await(t.Context(), promise.NewResolved(0, nil))
+	p.Resolve(7, nil)
 
-		p.Resolve(true, nil)
-
-		require.True(t, p.Resolved())
-		select {
-		case <-done:
-		default:
-			require.FailNow(t, "resolved done channel should not block")
-		}
-
-		require.True(t, p.Result)
-	})
-
-	t.Run("promise cannot be resolved twice", func(t *testing.T) {
-		p := NewPromise[bool]()
-		p.Resolve(false, errors.New("fail"))
-		p.Resolve(true, nil)
-
-		require.False(t, p.Result)
-		require.Error(t, p.Err)
-	})
-}
-
-func TestPromiseThen(t *testing.T) {
-	t.Run("callback runs on the resolving goroutine", func(t *testing.T) {
-		p := NewPromise[int]()
-
-		var (
-			gotResult int
-			gotErr    error
-			called    bool
-		)
-		p.Then(func(result int, err error) {
-			gotResult, gotErr, called = result, err, true
-		})
-		require.False(t, called, "callback should not run before resolution")
-
-		expErr := errors.New("fail")
-		var calledBeforeResolveReturned bool
-		resolved := make(chan struct{})
-		go func() {
-			defer close(resolved)
-			p.Resolve(7, expErr)
-			calledBeforeResolveReturned = called
-		}()
-
-		<-resolved
-		require.True(t, calledBeforeResolveReturned, "callback should have run before Resolve returned")
-		require.Equal(t, 7, gotResult)
-		require.Equal(t, expErr, gotErr)
-	})
-
-	t.Run("callback registered after resolution runs inline", func(t *testing.T) {
-		p := NewPromise[int]()
-		p.Resolve(7, nil)
-
-		var called bool
-		p.Then(func(result int, err error) {
-			called = true
-			require.Equal(t, 7, result)
-			require.NoError(t, err)
-		})
-		require.True(t, called, "callback should run before Then returned")
-	})
-
-	t.Run("callbacks run in registration order", func(t *testing.T) {
-		p := NewPromise[int]()
-
-		var order []int
-		for i := range 3 {
-			p.Then(func(int, error) { order = append(order, i) })
-		}
-		p.Resolve(0, nil)
-
-		require.Equal(t, []int{0, 1, 2}, order)
-	})
-
-	t.Run("callbacks run once when resolved twice", func(t *testing.T) {
-		p := NewPromise[int]()
-
-		var calls int
-		p.Then(func(int, error) { calls++ })
-
-		p.Resolve(1, nil)
-		p.Resolve(2, nil)
-
-		require.Equal(t, 1, calls)
-	})
-
-	t.Run("zero value and resolved promise accept callbacks", func(t *testing.T) {
-		var zero Promise[int]
-		var zeroCalled bool
-		zero.Then(func(result int, err error) { zeroCalled = true })
-		require.False(t, zeroCalled)
-		zero.Resolve(7, nil)
-		require.True(t, zeroCalled)
-
-		var resolvedCalled bool
-		NewResolvedPromise(7, nil).Then(func(result int, err error) {
-			resolvedCalled = true
-			require.Equal(t, 7, result)
-		})
-		require.True(t, resolvedCalled)
-	})
-
-	t.Run("callback can re-enter the promise", func(t *testing.T) {
-		p := NewPromise[int]()
-
-		var (
-			resolvedDuringCallback bool
-			awaitResult            int
-			awaitErr               error
-			nested                 bool
-		)
-		p.Then(func(int, error) {
-			resolvedDuringCallback = p.Resolved()
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			awaitResult, awaitErr = AwaitPromise(ctx, p)
-
-			p.Then(func(int, error) { nested = true })
-		})
-
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			p.Resolve(7, nil)
-		}()
-
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			require.FailNow(t, "re-entrant callback deadlocked")
-		}
-		require.True(t, resolvedDuringCallback)
-		require.Equal(t, 7, awaitResult)
-		require.NoError(t, awaitErr)
-		require.True(t, nested, "callback registered during dispatch should run inline")
-	})
+	result, err := AwaitPromise(t.Context(), p)
+	require.NoError(t, err)
+	require.Equal(t, 7, result)
 }


### PR DESCRIPTION
`utils` costs a consumer 497 packages. `codec.go` reaches `pion/webrtc` and the
74 packages behind it; the rest of the package pulls in `psrpc` and `nats`. A
caller whose only use of `utils` is `*utils.Promise` on one interface method
inherits all of it — and where that caller is translated for deterministic
simulation, so is every package in the closure.

This moves `Promise` and `DeepCopy` into `utils/promise` and `utils/deepcopy`,
which carry nothing beyond the standard library (`context` + `sync`, and
`reflect`).

| package | closure |
|---|---|
| `utils` | 497 |
| `utils/promise` | 40 |
| `utils/deepcopy` | 42 |

### Backward compatibility

Nothing is removed. `utils.Promise`, `NewPromise`, `GoPromise`,
`NewResolvedPromise`, `AwaitPromise` and `DeepCopy` all still resolve; the
Promise API has 44 call sites across five repos and `DeepCopy` six more.

`Promise` is a **type alias**, not a defined type, so a promise built under
either spelling satisfies an interface written against the other. That is the
case that actually matters: one package declares a seam returning
`*promise.Promise[T]` while another implements it by handing back what
`utils.Promise`-typed code produced. A defined type would compile fine here and
break only those callers, so `utils/promise_test.go` pins it at compile time.

Verified by building `backend-common` (17 files on the Promise API) and
`cloud-observability` (10) against this branch unchanged.

### Naming

Subpackage constructors drop the stutter: `promise.New`, `promise.Go`,
`promise.Await`, `deepcopy.Copy`. `NewResolved` keeps its prefix to stay clear
of the `Resolved` method, which reports whether a promise has settled rather
than producing one that has.
